### PR TITLE
Adding separate volume for js/dist folder.

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - './:/home/node/app'
       - '/home/node/app/node_modules'
+      - '/home/node/app/public/js/dist'
     ports:
       - "23017:8081"
     # Join this service to a custom docker network


### PR DESCRIPTION
**Adding separate volume for js/dist folder.*
* * *


# What does this Pull Request do?
This adds a new docker volume for `/home/node/app/public/js/dist` This is so the local folder does not override the container folder. This way Webpack can be built correctly through Dockerfile and DockerfileLocal on container build.

# How should this be tested?

A description of what steps someone could take to:
*On the `main` branch, delete all the files in your local `/mps-viewer/public/js/dist` folder
* Build the container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* The mirador viewer should not load at all on the site in your browser.
* If you bash into the container (`docker exec -it mps-viewer bash`) and go to the `/home/node/app/public/js/dist` folder you will see it is still empty even though webpack was run successfully.
* Take down your container: `docker-compose -f docker-compose-local.yml down`
* pull in the `fix-webpack` branch
* Rebuild the container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* The Mirador viewer should load correctly in your browser.
* If you bash into the container (`docker exec -it mps-viewer bash`) and go to the `/home/node/app/public/js/dist` folder you will see the Webpack generated files!

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No 
- integration tests? No

# Interested parties
@enriquediaz @mferrarini 