### PR TITLE
Adding ability to display any object in Netlify viewer.

### DIFF
--- a/public/js/netlify.js
+++ b/public/js/netlify.js
@@ -1,0 +1,22 @@
+
+function getObjectType() {
+    var url_string = window.location.href;
+    var url = new URL(url_string);
+    var letters = /^[A-Za-z]+$/;
+    var objectType = url.searchParams.get("type");
+    if (!letters.test(objectType) || objectType === undefined || objectType === null ) {
+        objectType='ids';
+    }
+    return objectType;
+}
+
+function getObjectId() {
+    var url_string = window.location.href;
+    var url = new URL(url_string);
+    var numbers = /^[0-9]+$/;
+    var objectId = url.searchParams.get("id");
+    if (!numbers.test(objectId)) {
+        objectId = 44753773;
+    }
+    return objectId;
+}

--- a/public/netlify.html
+++ b/public/netlify.html
@@ -9,10 +9,20 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://bootstrapbuildspace.sfo2.cdn.digitaloceanspaces.com//WCXlTrwTUnMt/ACnrgCvRXvVr/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/compiled/style.min.css">
+    <script src="/js/netlify.js"></script>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+  
+    <script type="application/javascript">
+      $(document).ready( function() {
+        var objectType = getObjectType();
+        var objectId = getObjectId();
+        $('#miradorViewer').attr('src','/viewer.html?type='+objectType+'&id='+objectId);
+      });
+    </script>
+  
   </head>
   <body>
     <header>
@@ -41,7 +51,7 @@
                         title="Mirador Viewer"
                         width="1200px"
                         height="700px"
-                        src="/viewer.html?type=ids&id=44753773"
+                        src=""
                         allowfullscreen="true">
                     </iframe>
                 </div>

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -5,10 +5,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Basic Mirador</title>
-    <script type="text/javascript">
+    <script src="/js/netlify.js"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script type="application/javascript">
+        var objectType = getObjectType();
+        var objectId = getObjectId();
         miradorOptions = {
-            objectType: 'ids',
-            objectId: 44753773,
+          objectType: objectType,
+          objectId: objectId,
         }
     </script>
   </head>

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Basic Mirador</title>
     <script src="/js/netlify.js"></script>
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script type="application/javascript">
         var objectType = getObjectType();
         var objectId = getObjectId();


### PR DESCRIPTION
**Adding ability to display any object in Netlify viewer.*
* * *

**JIRA Ticket**: [LTSVIEWER-82](https://jira.huit.harvard.edu/browse/LTSVIEWER-82)

# What does this Pull Request do?
This updates the netlify.html page to allow you to pass in request variables to display other objects besides the default.


# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container.
* Go to this page and confirm that the Igor Stravinsky item appears: https://localhost:23017/netlify.html
* There are two request variables. `type` and `id`. You Can go to any object in Harvard Digital Collections, click on the "copy manifest link" and use the variables in the manifest url to build the request variables here.
* For example, this item in HDC: https://digitalcollections.library.harvard.edu/catalog/W595562_URN-3:HUL.ARCH:4906440 can be viewed in Netlify at this url: https://localhost:23017/netlify.html?type=ids&id=25286148
* Other examples include https://localhost:23017/netlify.html?type=ids&id=47723272 or https://localhost:23017/netlify.html?type=drs&id=4997399
* It also includes basic validation for sql injection by making sure type is only alphabetic characters and id is only numeric characters. So if you do something like this, it'll fall back to Igor Stravinsky: https://localhost:23017/netlify.html?type=12345&id=something-invalid
* You can also confirm the non-Netlify version of MPS Viewer still works: https://localhost:23017/ or https://localhost:23017/example/drs/4997399 for example.


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 