### PR TITLE
Updating copyright date on netlify page.

### DIFF
--- a/public/netlify.html
+++ b/public/netlify.html
@@ -61,7 +61,7 @@
 
     <footer class="container-fluid hl__footer">
         <div class="row justify-content-between">
-            <div id="copyright" class="col-lg-9 col-md-6">&copy;2021 President and Fellows of Harvard College</div>
+            <div id="copyright" class="col-lg-9 col-md-6">&copy;2022 President and Fellows of Harvard College</div>
             <div id="feedback" class="col-lg-3 col-md-6"><a href="https://nrs.harvard.edu/urn-3:hul.ois:reportaproblem" target="_blank">Report a Problem</a></div>
           </div>
     </footer>


### PR DESCRIPTION
**Updating copyright date on netlify page.*
* * *



# What does this Pull Request do?
This just changes the copyright date in the footer of the Netlify page from 2021 to 2022.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container.
* Go to the Netlify page and note that the copyright date is 2022: https://mps-viewer.netlify.app/netlify.html

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

