### PR TITLE
Viewer example now completely uses mps-embed service.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,3 @@
 {
-    "esversion": 6
+    "esversion": 8
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:lts-alpine
 
 # Install packages
-RUN apk add --no-cache bash && \
+RUN apk update && \ 
+  apk add --no-cache bash && \
   apk add curl && \
   apk add openssl && \
   deluser --remove-home node && \
@@ -10,7 +11,7 @@ RUN apk add --no-cache bash && \
 USER node
 # Append SAN section to openssl.cnf and generate a new self-signed certificate and key
 RUN mkdir -p /home/node/ssl/certs && \
-    cp /etc/ssl/openssl.cnf /home/node/ssl/openssl.cnf && \
+    cp /etc/ssl1.1/openssl.cnf /home/node/ssl/openssl.cnf && \
     printf "[SAN]\nsubjectAltName=DNS:*.hul.harvard.edu,DNS:*.lts.harvard.edu" >> /home/node/ssl/openssl.cnf && \
     openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Library Technology Services/CN=*.lib.harvard.edu" -extensions SAN -reqexts SAN -config /home/node/ssl/openssl.cnf -keyout /home/node/ssl/certs/server.key -out /home/node/ssl/certs/server.crt && \
     mkdir -p /home/node/app

--- a/DockerfileLocal
+++ b/DockerfileLocal
@@ -1,7 +1,8 @@
 FROM node:lts-alpine
 
 # Install packages
-RUN apk add --no-cache bash && \
+RUN apk update && \ 
+  apk add --no-cache bash && \
   apk add curl && \
   apk add openssl && \
   deluser --remove-home node && \
@@ -10,7 +11,7 @@ RUN apk add --no-cache bash && \
 USER node
 # Append SAN section to openssl.cnf and generate a new self-signed certificate and key
 RUN mkdir -p /home/node/ssl/certs && \
-    cp /etc/ssl/openssl.cnf /home/node/ssl/openssl.cnf && \
+    cp /etc/ssl1.1/openssl.cnf /home/node/ssl/openssl.cnf && \
     printf "[SAN]\nsubjectAltName=DNS:*.hul.harvard.edu,DNS:*.lts.harvard.edu" >> /home/node/ssl/openssl.cnf && \
     openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Library Technology Services/CN=*.lib.harvard.edu" -extensions SAN -reqexts SAN -config /home/node/ssl/openssl.cnf -keyout /home/node/ssl/certs/server.key -out /home/node/ssl/certs/server.crt && \
     mkdir -p /home/node/app

--- a/controllers/embed.ctrl
+++ b/controllers/embed.ctrl
@@ -1,0 +1,27 @@
+const https = require('https');
+const axios = require('axios');
+
+const embedCtrl = {};
+
+embedCtrl.getEmbed = async (recordIdentifier) => {
+    let result = {};
+
+    let response;
+    try {
+      response = await axios.get(process.env.EMBED_BASE_URL+'/api?recordIdentifier='+recordIdentifier);
+    } catch(e) {
+      const errorMsg = e.response && e.response.data ? e.response.data : e.code;
+      console.log(errorMsg);
+      result.error = errorMsg;
+      result.status = result.error.status || 500;
+      return result;
+    }
+  
+    result.error = '';
+    result.status = response && response.status || 500;
+    result.data = response && response.data || {};
+
+     return result;
+};
+
+module.exports = embedCtrl;

--- a/controllers/embed.ctrl
+++ b/controllers/embed.ctrl
@@ -7,13 +7,26 @@ embedCtrl.getEmbed = async (recordIdentifier) => {
     let result = {};
 
     let response;
+
+    let rejectUnauthorizedCert = true;
+    if (process.env.REJECT_UNAUTHORIZED_CERT === 'false') {
+      rejectUnauthorizedCert = false;
+    }
+    // At instance level
+    const instance = axios.create({
+      httpsAgent: new https.Agent({  
+        rejectUnauthorized: rejectUnauthorizedCert
+      })
+    });
+
     try {
-      response = await axios.get(process.env.EMBED_BASE_URL+'/api?recordIdentifier='+recordIdentifier);
+      response = await instance.get(process.env.EMBED_BASE_URL+'/api?recordIdentifier='+recordIdentifier);
     } catch(e) {
       const errorMsg = e.response && e.response.data ? e.response.data : e.code;
       console.log(errorMsg);
       result.error = errorMsg;
       result.status = result.error.status || 500;
+      result.data = {};
       return result;
     }
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.7'
 services:
 
   app:
-    image: registry.lts.harvard.edu/lts/mps-viewer:0.0.4
+    image: registry.lts.harvard.edu/lts/mps-viewer:0.0.5
     build:
       context: ./
       dockerfile: Dockerfile

--- a/env-example.txt
+++ b/env-example.txt
@@ -1,2 +1,5 @@
 # Environment 'development', 'test', or 'production'
 ENV=development
+
+# Determine what embed server to use
+#EMBED_BASE_URL=https://localhost:23018

--- a/env-example.txt
+++ b/env-example.txt
@@ -2,4 +2,7 @@
 ENV=development
 
 # Determine what embed server to use
-#EMBED_BASE_URL=https://localhost:23018
+EMBED_BASE_URL=https://<your IPV4 address>:23018
+
+# Set this to 'false' for local testing. Set to 'true' for other environments
+REJECT_UNAUTHORIZED_CERT=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mps-viewer",
       "version": "1.0.0",
       "dependencies": {
+        "axios": "^0.24.0",
         "body-parser": "^1.19.0",
         "bootstrap": "^4.6.0",
         "cookie-parser": "^1.4.5",
@@ -1298,6 +1299,14 @@
       "version": "3.2.2",
       "license": "MIT"
     },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "node_modules/babel-loader": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
@@ -2358,6 +2367,25 @@
     "node_modules/fn.name": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
+      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -6331,6 +6359,14 @@
     "async": {
       "version": "3.2.2"
     },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "babel-loader": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
@@ -7061,6 +7097,11 @@
     },
     "fn.name": {
       "version": "1.1.0"
+    },
+    "follow-redirects": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
+      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
     },
     "forwarded": {
       "version": "0.2.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "webpack": "webpack --config webpack/webpack.config.js"
   },
   "dependencies": {
+    "axios": "^0.24.0",
     "body-parser": "^1.19.0",
     "bootstrap": "^4.6.0",
     "cookie-parser": "^1.4.5",

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,8 +2,9 @@ const express = require('express');
 const router = express.Router();
 const qs = require('query-string');
 const eta = require('eta');
-
 const path = require('path');
+const embedCtrl = require('../controllers/embed.ctrl');
+
 
 const { body,validationResult } = require('express-validator');
 
@@ -18,12 +19,17 @@ router.get("/", function (req, res) {
   });
 });
 
-router.get("/example/:objectType/:objectId", function (req, res) {
+router.get("/example/:recordIdentifier", async function (req, res) {
+    embed = await embedCtrl.getEmbed(req.params.recordIdentifier);
+
+    viewerURL = embed.data.html;
+    title = embed.data.title;
+    iiifManifest = embed.data.iiif_manifest;
+
     res.render("example", {
-        title: "Docker NodeJS Template!",
-        body: "Hello, World!",
-        objectType: req.params.objectType,
-        objectId: req.params.objectId,
+        title: title,
+        viewerURL: viewerURL,
+        iiifManifest: iiifManifest,
     });
 });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -14,22 +14,36 @@ const getUserFromReq = (req) => {
 
 router.get("/", function (req, res) {
   res.render("index", {
-      title: "Docker NodeJS Template!",
-      body: "Hello, World!",
+      title: "Welcome to the MPS Viewer!",
   });
 });
 
 router.get("/example/:recordIdentifier", async function (req, res) {
+    let viewerURL = '';
+    let title = '';
+    let iiifManifest = '';
+    let errorMsg = '';
+
     embed = await embedCtrl.getEmbed(req.params.recordIdentifier);
 
-    viewerURL = embed.data.html;
-    title = embed.data.title;
-    iiifManifest = embed.data.iiif_manifest;
+    if (embed.hasOwnProperty('error')) {
+        errorMsg = embed.error;
+    }
+    if (embed.data.hasOwnProperty('html')) {
+        viewerURL = embed.data.html;
+    }
+    if (embed.data.hasOwnProperty('title')) { 
+        title = embed.data.title;
+    }
+    if (embed.data.hasOwnProperty('iiif_manifest')) {
+        iiifManifest = embed.data.iiif_manifest;
+    }
 
     res.render("example", {
         title: title,
         viewerURL: viewerURL,
         iiifManifest: iiifManifest,
+        error: errorMsg,
     });
 });
 

--- a/views/example.eta
+++ b/views/example.eta
@@ -19,9 +19,7 @@
     <% if (it.viewerURL) { %>
     <div class="row">
         <div class="col-md-12">
-            <%= it.viewerURL %>
-            <%~ '<iframe src=\"https://viewer-qa.lib.harvard.edu/viewer/ids/10274484\" height=\"700px\" width=\"1200px\" title=\"MPS Viewer\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\" allowfullscreen></iframe>\n' %>
-
+            <%~ it.viewerURL %>
         </div>
     </div>
     <% } %>

--- a/views/example.eta
+++ b/views/example.eta
@@ -3,13 +3,26 @@
 <div id="main-container" class="container">
     <div class="row">
         <div class="col-md-12">
-            <iframe id="miradorViewer"
-                title="Mirador Viewer"
-                width="1200px"
-                height="700px"
-                src="/viewer/<%= it.objectType %>/<%= it.objectId %>"
-                allowfullscreen="true">
-            </iframe>
+            <h2><%= it.title %></h2>
+            <% if (it.iiifManifest) { %>
+            <p>
+                <b>IIIF Manifest:</b> <a href="<%= it.iiifManifest %>" target="_blank"><%= it.iiifManifest %></a>
+            </p>
+            <% } %>
+            <% if (it.error) { %>
+            <p>
+                <b>Error Message:</b> <%~ it.error %>
+            </p>
+            <% } %>
         </div>
     </div>
+    <% if (it.viewerURL) { %>
+    <div class="row">
+        <div class="col-md-12">
+            <%= it.viewerURL %>
+            <%~ '<iframe src=\"https://viewer-qa.lib.harvard.edu/viewer/ids/10274484\" height=\"700px\" width=\"1200px\" title=\"MPS Viewer\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\" allowfullscreen></iframe>\n' %>
+
+        </div>
+    </div>
+    <% } %>
 </div>

--- a/views/index.eta
+++ b/views/index.eta
@@ -3,7 +3,7 @@
 <div id="main-container" class="container">
   <div class="row">
       <div class="col-md-12">
-        <h2>Welcome to the MPS Viewer!</h2>
+        <h2><%= it.title %></h2>
       </div>
   </div>
   <div class="row">

--- a/views/index.eta
+++ b/views/index.eta
@@ -9,10 +9,13 @@
   <div class="row">
       <div class="col-md-12">
         <div class="list-group">
-          <a href="/example/ids/10274484" class="list-group-item list-group-item-action">Harvard University, Harvard University Archives, W401827_1m</a>
-          <a href="/example/ids/42929359" class="list-group-item list-group-item-action">Untitled Drumset</a>
-          <a href="/example/drs/48309543" class="list-group-item list-group-item-action">Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass.</a>
-        </div>
+          <a href="/example/W401849_URN-3:HUL.ARCH:2009749" class="list-group-item list-group-item-action">Harvard University Baseball Team, photograph, 1892</a>
+          <a href="/example/W401827_URN-3:HUL.ARCH:2009747" class="list-group-item list-group-item-action">Harvard-Yale Baseball Game. Holmes Field, photograph, 1885</a>
+          <a href="/example/W587091_URN-3:RAD.SCHL:11680642" class="list-group-item list-group-item-action">To roast a chicken; show #217</a>
+          <a href="/example/HUAM140429_URN-3:HUAM:INV012574P_DYNMC" class="list-group-item list-group-item-action">Untitled Drumset</a>
+          <a href="/example/990100671200203941" class="list-group-item list-group-item-action">Hot Dog In The Manger</a>
+          <a href="/example/990095204340203941" class="list-group-item list-group-item-action">Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass.</a>
+       </div>
       </div>
   </div>
 </div>


### PR DESCRIPTION
**Viewer example now completely uses mps-embed service.**
* * *

**JIRA Ticket**: [LTSVIEWER-102](https://jira.huit.harvard.edu/browse/LTSVIEWER-102)

# What does this Pull Request do?
This uses the mps-embed service to display the viewer in the example pages, instead of  using object type and object id from the request variables.

The path now expects the recordIdentifer which it the mps-embed service uses to return the JSON oEmbed response. The response is then used to embed the Viewer in an `<iframe>` on the page.

Additionally, something changed over the winter break with openssl and the lts-alpine Docker image. The `/etc/ssl/openssl.cnf` file has been moved to `/etc/ssl1.1/openssl.cnf`. If you build the container off of the `main` branch it will fail because it cannot find the file.

Finally, it adds new environment variable `EMBED_BASE_URL` that allows you to set it to whatever mps-embed server you wish, including your local instance. There is anothe rnew environment variable `REJECT_UNAUTHORIZED_CERT` that is used to allow local development. The Axios API calls will not work with self-signed-certificates unless a configuration variable called `rejectUnauthorized` is set to `false`. This request variable allows us to set this locally, while keeping it more secure in our server environments.

# How should this be tested?

* Set the `REJECT_UNAUTHORIZED_CERT` variable to be `false` in your `.env`
* Set the `EMBED_BASE_URL` variable to be your local mps-embed service. You need to use your computer's current ipv4 address including the port number and not "localhost". In my case it is [xxxxx](https://192.168.1.231:23018). See [these instructions for finding your ipv4 address on a Mac](https://www.hellotech.com/guide/for/how-to-find-ip-address-on-mac).
* Setting the `EMBED_BASE_URL` variable to dev and qa will not work right now, as the code from [this PR](https://github.com/harvard-lts/mps-embed/pull/4) has not yet been deployed to those environments.
* Build and run your local `mps-embed` container first!
* Completely rebuild the mps-viewer container.
* Going to every item on the homepage, you should see the Title, IIIF Manifest URL and Viewer for the item displaying properly on the page.
* If you view the source, you should see the `<iframe>` tag it uses is pointing to the viewer you have set in the `.env` of your local `mps-embed` instance. 
* You should be able to plug in another recordIdentifier in the URL and it should display the item properly. For example: https://localhost:23017/example/8000981781_URN-3:RAD.SCHL:23779039

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No 
- integration tests? No

# Interested parties
@enriquediaz 