### PR TITLE
Add passing tests. Add GitHub Action that runs unit tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Run webpack
         run: npm run webpack
       - name: Run tests
-        run: npm run test
+        run: npm run test:unit
       - run: echo "This job's status is ${{ job.status }}."  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Automated Testing
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Install modules
+        run: npm install
+      - name: Run webpack
+        run: npm run webpack
+      - name: Run tests
+        run: npm run test
+      - run: echo "This job's status is ${{ job.status }}."  

--- a/__tests__/a.test.js
+++ b/__tests__/a.test.js
@@ -1,3 +1,0 @@
-test('3 equal 3', () => {
-    expect(3).toBe(3);
-  });

--- a/__tests__/integration/healthchecks.test.js
+++ b/__tests__/integration/healthchecks.test.js
@@ -1,0 +1,102 @@
+const axios = require('axios');
+const https = require('https');
+const app = require('../../app.js');
+const supertest = require('supertest');
+
+axios.defaults.adapter = require('axios/lib/adapters/http');
+axios.defaults.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+beforeAll( async () => {
+    console.log('Running healthcheck tests.');
+});
+
+/**
+ * Smoke tests
+ * @group smoke
+ */
+ describe('Test MPS Embed Healthcheck', () => {
+    test('Successful response from healthcheck route', async () => {
+        const converter_healthcheck_route = process.env.EMBED_BASE_URL + '/healthcheck';
+        const response = await axios.get(converter_healthcheck_route)
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(200);
+        expect(response.data.hasOwnProperty('message'));
+        expect(response.data['message']).toBeDefined();
+        expect(response.data['message']).not.toBeNull();
+    });
+});
+
+describe('Test MPS Viewer Healthcheck', () => {
+    test('Successful response from healthcheck route', async () => {
+        let testsAgent = supertest.agent(app);
+        const response = await testsAgent.get('/healthcheck')
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(200);
+        expect(response.body.hasOwnProperty('message'));
+        expect(response.body['message']).toBeDefined();
+        expect(response.body['message']).not.toBeNull();
+    });
+});
+
+describe('Test MPS Viewer Homepage', () => {
+    test('Successful response from homepage route', async () => {
+        let testsAgent = supertest.agent(app);
+        const response = await testsAgent.get('/')
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(200);
+    });
+});
+
+describe('Test MPS Viewer 404', () => {
+    test('Successful 404 response', async () => {
+        let testsAgent = supertest.agent(app);
+        const response = await testsAgent.get('/abc/123')
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(404);
+    });
+});
+
+describe('Test MPS Viewer Route', () => {
+    test('Successful response from viewer route', async () => {
+        let testsAgent = supertest.agent(app);
+        let objectType = 'ids';
+        let objectId = '42929359';
+        const response = await testsAgent.get('/viewer/'+ objectType +'/'+ objectId)
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(200);
+    });
+});
+
+describe('Test MPS Viewer Successful Example Route', () => {
+    test('Successful response from example route', async () => {
+        let testsAgent = supertest.agent(app);
+        let recordIdentifier = 'HUAM140429_URN-3:HUAM:INV012574P_DYNMC';
+        const response = await testsAgent.get('/example/'+ recordIdentifier)
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(200);
+    });
+});
+
+describe('Test MPS Viewer Failed Example Route', () => {
+    test('Failed response from example route', async () => {
+        let testsAgent = supertest.agent(app);
+        let recordIdentifier = '12345';
+        const response = await testsAgent.get('/example/'+ recordIdentifier)
+            .catch(function (error) {
+                console.log(error);
+            });
+        expect(response.status).toBe(200);
+    });
+});

--- a/__tests__/unit/embed.test.js
+++ b/__tests__/unit/embed.test.js
@@ -1,0 +1,28 @@
+const embedCtrl = require('../../controllers/embed.ctrl');
+const consoleLogger = require('../../logger/logger.js').console;
+
+describe('Embed', () => {
+    test('Successful response from getEmbed', async () => {
+        let recordIdentifier = 'HUAM140429_URN-3:HUAM:INV012574P_DYNMC';
+        try {
+          embed = await embedCtrl.getEmbed(recordIdentifier);
+        } catch (e) {
+          const errorMsg = `Unable to validate getEmbed: ${e}`;
+          consoleLogger.error(errorMsg);
+        }
+    
+        expect(embed).not.toBeNull();
+    });
+    test('Unsuccessful response from getEmbed', async () => {
+        let recordIdentifier = '12345';
+        try {
+          embed = await embedCtrl.getEmbed(recordIdentifier);
+        } catch (e) {
+          const errorMsg = `Unable to validate getEmbed: ${e}`;
+          consoleLogger.error(errorMsg);
+        }
+    
+        expect(embed).not.toBeNull();
+    });
+   
+});

--- a/app.js
+++ b/app.js
@@ -21,8 +21,8 @@ const indexRouter = require('./routes/index');
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'eta')
-app.engine('eta', eta.renderFile)
+app.set('view engine', 'eta');
+app.engine('eta', eta.renderFile);
 
 
 // set path for static assets
@@ -56,7 +56,7 @@ app.use(requestLogger('combined', { stream: requestLogStream, flags: 'a', skip: 
 
 // Routes
 app.use(['/healthcheck'], (req, res, next) => {
-    res.status(200).json({ "status": 200, "message": "docker-nodejs-template" });
+    res.status(200).json({ "status": 200, "message": "mps-viewer" });
 });
 app.use('/', indexRouter);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.7'
 services:
 
   app:
-    image: registry.lts.harvard.edu/lts/mps-viewer:0.0.5
+    image: registry.lts.harvard.edu/lts/mps-viewer:0.0.6
     build:
       context: ./
       dockerfile: Dockerfile

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,12 +34,13 @@ module.exports = {
   // coverageProvider: "babel",
 
   // A list of reporter names that Jest uses when writing coverage reports
-  // coverageReporters: [
-  //   "json",
-  //   "text",
-  //   "lcov",
-  //   "clover"
-  // ],
+   coverageReporters: [
+     "json",
+     "text",
+     "lcov",
+     "clover",
+     "json-summary",
+   ],
 
   // An object that configures minimum threshold enforcement for coverage results
   // coverageThreshold: undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eta": "^1.12.3",
         "express": "^4.17.1",
         "express-validator": "^6.13.0",
-        "jest-coverage-badges": "^1.1.2",
+        "jest-coverage-badges-ts": "^0.1.4",
         "jquery": "^3.6.0",
         "mirador": "^3.2.0",
         "mirador-dl-plugin": "^0.13.0",
@@ -4615,15 +4615,12 @@
       "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
       "dev": true
     },
-    "node_modules/jest-coverage-badges": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/jest-coverage-badges/-/jest-coverage-badges-1.1.2.tgz",
-      "integrity": "sha512-44A7i2xR6os8+fWk8ZRM6W4fKiD2jwKOLU9eB3iTIIWACd9RbdvmiCNpQZTOsUBhKvz7aQ/ASFhu5JOEhWUOlg==",
-      "dependencies": {
-        "mkdirp": "0.5.1"
-      },
+    "node_modules/jest-coverage-badges-ts": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/jest-coverage-badges-ts/-/jest-coverage-badges-ts-0.1.4.tgz",
+      "integrity": "sha512-lkxnwpC6/4nFCzgRK1MrAyAsa+cnUQBcQcJLHSYPFPYYh5hLFp2Zg4SxR4k4BXZwxtg8jt75B3IczmWOJuiDAw==",
       "bin": {
-        "jest-coverage-badges": "cli.js"
+        "jest-coverage-badges-ts": "dist/cli.js"
       },
       "engines": {
         "node": ">=6.11",
@@ -5717,23 +5714,6 @@
         "react-copy-to-clipboard": "^5.0.1",
         "react-dom": "16.x"
       }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "dependencies": {
-        "minimist": "0.0.8"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp/node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "node_modules/moment": {
       "version": "2.29.1",
@@ -11708,13 +11688,10 @@
         }
       }
     },
-    "jest-coverage-badges": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/jest-coverage-badges/-/jest-coverage-badges-1.1.2.tgz",
-      "integrity": "sha512-44A7i2xR6os8+fWk8ZRM6W4fKiD2jwKOLU9eB3iTIIWACd9RbdvmiCNpQZTOsUBhKvz7aQ/ASFhu5JOEhWUOlg==",
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+    "jest-coverage-badges-ts": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/jest-coverage-badges-ts/-/jest-coverage-badges-ts-0.1.4.tgz",
+      "integrity": "sha512-lkxnwpC6/4nFCzgRK1MrAyAsa+cnUQBcQcJLHSYPFPYYh5hLFp2Zg4SxR4k4BXZwxtg8jt75B3IczmWOJuiDAw=="
     },
     "jest-diff": {
       "version": "27.4.6",
@@ -12535,21 +12512,6 @@
     "mirador-share-plugin": {
       "version": "0.11.0",
       "requires": {}
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
     },
     "moment": {
       "version": "2.29.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eta": "^1.12.3",
         "express": "^4.17.1",
         "express-validator": "^6.13.0",
+        "jest-coverage-badges": "^1.1.2",
         "jquery": "^3.6.0",
         "mirador": "^3.2.0",
         "mirador-dl-plugin": "^0.13.0",
@@ -42,7 +43,8 @@
         "babel-loader": "^8.2.3",
         "clean-webpack-plugin": "^4.0.0",
         "jest": "^27.4.7",
-        "nodemon": "^2.0.13"
+        "nodemon": "^2.0.13",
+        "supertest": "^6.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2016,6 +2018,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "node_modules/async": {
       "version": "3.2.2",
       "license": "MIT"
@@ -2387,6 +2395,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2666,6 +2687,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -2734,6 +2761,12 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "dev": true
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.1",
@@ -2976,6 +3009,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -3418,6 +3461,12 @@
       "version": "2.5.2",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -3526,6 +3575,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
+      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0",
+        "qs": "6.9.3"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/formidable/node_modules/qs": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "license": "MIT",
@@ -3584,6 +3660,20 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -3733,10 +3823,31 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-yarn": {
       "version": "2.1.0",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4503,6 +4614,21 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
       "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
       "dev": true
+    },
+    "node_modules/jest-coverage-badges": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jest-coverage-badges/-/jest-coverage-badges-1.1.2.tgz",
+      "integrity": "sha512-44A7i2xR6os8+fWk8ZRM6W4fKiD2jwKOLU9eB3iTIIWACd9RbdvmiCNpQZTOsUBhKvz7aQ/ASFhu5JOEhWUOlg==",
+      "dependencies": {
+        "mkdirp": "0.5.1"
+      },
+      "bin": {
+        "jest-coverage-badges": "cli.js"
+      },
+      "engines": {
+        "node": ">=6.11",
+        "npm": ">=5.3"
+      }
     },
     "node_modules/jest-diff": {
       "version": "27.4.6",
@@ -5592,6 +5718,23 @@
         "react-dom": "16.x"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp/node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
     "node_modules/moment": {
       "version": "2.29.1",
       "license": "MIT",
@@ -5760,6 +5903,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-finished": {
@@ -6934,6 +7086,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.5",
       "license": "ISC"
@@ -7125,6 +7291,134 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.0.2.tgz",
+      "integrity": "sha512-2Kx35bZxLLJMBKtuXezxvD0aZQ7l923VwoCn7EtUx+aFxdG7co7PeRIddfrNtvvMuGaLZXA0mKzX+yWRhjrJ7A==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.3",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
+        "methods": "^1.1.2",
+        "mime": "^2.5.0",
+        "qs": "^6.10.1",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/superagent/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.2.1.tgz",
+      "integrity": "sha512-2kBKhfZgnPLmjpzB0n7A2ZnEAWTaLXq4bn3EEVY9w8rUpLyIlSusqKKvWA1Cav7hxXBnXGpxBsSeOHj5wQGe1Q==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -9569,6 +9863,12 @@
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "async": {
       "version": "3.2.2"
     },
@@ -9832,6 +10132,16 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -10028,6 +10338,12 @@
       "version": "1.0.1",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "dev": true
@@ -10074,6 +10390,12 @@
     },
     "cookie-signature": {
       "version": "1.0.6"
+    },
+    "cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "dev": true
     },
     "copy-to-clipboard": {
       "version": "3.3.1",
@@ -10259,6 +10581,16 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff-sequences": {
       "version": "27.4.0",
@@ -10571,6 +10903,12 @@
     "fast-memoize": {
       "version": "2.5.2"
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -10644,6 +10982,26 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
+      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "dev": true,
+      "requires": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0",
+        "qs": "6.9.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+          "dev": true
+        }
+      }
+    },
     "forwarded": {
       "version": "0.2.0"
     },
@@ -10680,6 +11038,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -10784,8 +11153,20 @@
       "version": "3.0.0",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
     "has-yarn": {
       "version": "2.1.0",
+      "dev": true
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
     "hoist-non-react-statics": {
@@ -11325,6 +11706,14 @@
           "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
           "dev": true
         }
+      }
+    },
+    "jest-coverage-badges": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jest-coverage-badges/-/jest-coverage-badges-1.1.2.tgz",
+      "integrity": "sha512-44A7i2xR6os8+fWk8ZRM6W4fKiD2jwKOLU9eB3iTIIWACd9RbdvmiCNpQZTOsUBhKvz7aQ/ASFhu5JOEhWUOlg==",
+      "requires": {
+        "mkdirp": "0.5.1"
       }
     },
     "jest-diff": {
@@ -12147,6 +12536,21 @@
       "version": "0.11.0",
       "requires": {}
     },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
     "moment": {
       "version": "2.29.1"
     },
@@ -12263,6 +12667,12 @@
     },
     "object-hash": {
       "version": "2.2.0"
+    },
+    "object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
@@ -13072,6 +13482,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.5"
     },
@@ -13199,6 +13620,98 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "dev": true
+    },
+    "superagent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.0.2.tgz",
+      "integrity": "sha512-2Kx35bZxLLJMBKtuXezxvD0aZQ7l923VwoCn7EtUx+aFxdG7co7PeRIddfrNtvvMuGaLZXA0mKzX+yWRhjrJ7A==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.3",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
+        "methods": "^1.1.2",
+        "mime": "^2.5.0",
+        "qs": "^6.10.1",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.2.1.tgz",
+      "integrity": "sha512-2kBKhfZgnPLmjpzB0n7A2ZnEAWTaLXq4bn3EEVY9w8rUpLyIlSusqKKvWA1Cav7hxXBnXGpxBsSeOHj5wQGe1Q==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^7.0.2"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "devstart": "nodemon ./bin/www -L",
     "devserverstart": "DEBUG=mirador-sandbox:* npm run devstart",
     "webpack": "webpack --config webpack/webpack.config.js",
-    "test": "jest"
+    "test": "./node_modules/.bin/jest",
+    "test:watch": "./node_modules/.bin/jest --watchAll",
+    "test:coverage": "./node_modules/.bin/jest --coverage",
+    "test:badges": "npm run test:coverage  && jest-coverage-badges",
+    "test:unit": "./node_modules/.bin/jest --testPathPattern=__tests__/unit",
+    "test:integration": "./node_modules/.bin/jest --testPathPattern=__tests__/integration"
   },
   "dependencies": {
     "axios": "^0.24.0",
@@ -19,6 +24,7 @@
     "eta": "^1.12.3",
     "express": "^4.17.1",
     "express-validator": "^6.13.0",
+    "jest-coverage-badges": "^1.1.2",
     "jquery": "^3.6.0",
     "mirador": "^3.2.0",
     "mirador-dl-plugin": "^0.13.0",
@@ -46,6 +52,7 @@
     "babel-loader": "^8.2.3",
     "clean-webpack-plugin": "^4.0.0",
     "jest": "^27.4.7",
-    "nodemon": "^2.0.13"
+    "nodemon": "^2.0.13",
+    "supertest": "^6.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "./node_modules/.bin/jest",
     "test:watch": "./node_modules/.bin/jest --watchAll",
     "test:coverage": "./node_modules/.bin/jest --coverage",
-    "test:badges": "npm run test:coverage  && jest-coverage-badges",
+    "test:badges": "npm run test:coverage  && jest-coverage-badges-ts",
     "test:unit": "./node_modules/.bin/jest --testPathPattern=__tests__/unit",
     "test:integration": "./node_modules/.bin/jest --testPathPattern=__tests__/integration"
   },
@@ -24,7 +24,7 @@
     "eta": "^1.12.3",
     "express": "^4.17.1",
     "express-validator": "^6.13.0",
-    "jest-coverage-badges": "^1.1.2",
+    "jest-coverage-badges-ts": "^0.1.4",
     "jquery": "^3.6.0",
     "mirador": "^3.2.0",
     "mirador-dl-plugin": "^0.13.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,10 +8,6 @@ const embedCtrl = require('../controllers/embed.ctrl');
 
 const { body,validationResult } = require('express-validator');
 
-const getUserFromReq = (req) => {
-    return req.token && req.token.user || null;
-}
-
 router.get("/", function (req, res) {
   res.render("index", {
       title: "Welcome to the MPS Viewer!",


### PR DESCRIPTION
**Add passing tests. Add GitHub Action that runs unit tests.**
* * *

**JIRA Tickets**: [LTSVIEWER-103](https://jira.huit.harvard.edu/browse/LTSVIEWER-103) [LTSVIEWER-100](https://jira.huit.harvard.edu/browse/LTSVIEWER-100)

* Other Relevant Links:
  - [MPS Asset Delivery Images Testing Scripts](https://github.huit.harvard.edu/LTS/mps-asset-delivery-images/blob/main/app/package.json#L9-L12)
  - [MPS Asset Delivery Images Test Folder](https://github.huit.harvard.edu/LTS/mps-asset-delivery-images/tree/main/app/__tests__)
  - [SysDev Automated Tests Wiki](https://wiki.harvard.edu/confluence/pages/viewpage.action?spaceKey=LibraryTechServices&title=SysDev+-+Automated+tests)

# What does this Pull Request do?
This PR adds Unit Tests and Integration Tests for Viewer. I based this off of the examples provided in the MPS Asset Delivery Images repository and the SysDev Automated Tests Wiki (both linked above in the Relevant Links). The integration tests require you to be running `mps-embed` and `mps-viewer` applications simultaneously to pass. There is also a new GitHub Action that just runs the Unit tests (which does not require integration with `mps-embed`). The Github action passed when I deployed to this branch in [Job #2](https://github.com/harvard-lts/mps-viewer/runs/4858315421?check_suite_focus=true). 

# How should this be tested?

A description of what steps someone could take to:
* Build and run the `mps-viewer` container off of the `add-real-tests` branch
* Build and run the `mps-embed` container off of the `main` branch
* ssh into the mps-viewer container: `docker exec -it mps-viewer bash`
* Run each of the test scripts and confirm they all pass. The available test scripts are:
  - `npm run test` (This runs both unit and integration tests)
  - `npm run test:unit` (This runs only the unit tests)
  - `npm run test:integration` (This runs only the integration tests)
  - `npm run test:coverage` (This runs all the tests and creates a `/coverage/` folder with coverage reports)
  - `npm run test:badges`(This runs all the tests and creates badge image files in the `/coverage/` folder)

**NOTE:** The `/coverage` folder is in `.gitignore` so the files are not committed to the Github repository. You can look at the report it generates by opening the local index file in your browser (the application does not have a "route" to the report.  The index file is located at: `/mps-viewer/coverage/lcov-report/index.html`. You can see the badge images it creates a similar way with `/mps-viewer/coverage/badge-branches.svg` and the other .svg files located in the `/coverage` folder. Integration of the badges and the repo's `README.md` coming soon in a different PR.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Yes
- integration tests? Yes

# Interested parties
@awoods @enriquediaz 