### PR TITLE
Add Integration Tests to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ENV: development
     steps:
       - uses: actions/checkout@v2
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -13,5 +15,8 @@ jobs:
       - name: Run webpack
         run: npm run webpack
       - name: Run tests
+        env: 
+          EMBED_BASE_URL: https://embed-dev.lib.harvard.edu
+          REJECT_UNAUTHORIZED_CERT: false
         run: npm run test
       - run: echo "This job's status is ${{ job.status }}."  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Run webpack
         run: npm run webpack
       - name: Run tests
-        run: npm run test:unit
+        run: npm run test
       - run: echo "This job's status is ${{ job.status }}."  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         run: npm run webpack
       - name: Run tests
         env: 
-          EMBED_BASE_URL: https://embed-dev.lib.harvard.edu
+          EMBED_BASE_URL: https://embed-qa.lib.harvard.edu
           REJECT_UNAUTHORIZED_CERT: false
         run: npm run test
       - run: echo "This job's status is ${{ job.status }}."  


### PR DESCRIPTION
**Add Integration Tests to Github Actions*
* * *


# What does this Pull Request do?
This adds the integration tests to the Github Actions script. It uses embed-qa as the healthcheck test, via an environment variable.

# How should this be tested?

A description of what steps someone could take to:
* You could install Act (https://github.com/nektos/act) and confirm the Github Action runs successfully by running the `act` command.
* Or you could see the last action I ran for this branch successfully finished here: https://github.com/harvard-lts/mps-viewer/runs/4898648704?check_suite_focus=true

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Yes
- integration tests? Yes

# Interested parties
@enriquediaz 