### PR TITLE
Fixing query selectors.

### DIFF
--- a/plugins/hide_viewer_navigation.js
+++ b/plugins/hide_viewer_navigation.js
@@ -26,18 +26,9 @@ class hideViewerNavigation extends Component {
     let viewingHint = this.viewingHint();
 
     if (viewingHint == 'individuals') {
-      const caption = window.document.getElementsByClassName("mirador-osd-info"); 
-      const pager = window.document.getElementsByClassName("mirador-osd-navigation");
-      const divider = window.document.getElementsByClassName("Connect(WithPlugins(ZoomControls))-divider-91");
-      while(caption.length > 0){ 
-        caption[0].parentNode.removeChild(caption[0]);
-      }
-      while(pager.length > 0){ 
-          pager[0].parentNode.removeChild(pager[0]);
-      }
-      while(divider.length > 0){ 
-        divider[0].parentNode.removeChild(divider[0]);
-    }
+      window.document.querySelectorAll('.mirador-osd-info').forEach((elem) => elem.remove());
+      window.document.querySelectorAll('.mirador-osd-navigation').forEach((elem) => elem.remove());
+      window.document.querySelectorAll('[class*="Connect(WithPlugins(ZoomControls))-divider-"]').forEach((elem) => elem.remove());
     }
   }
 }


### PR DESCRIPTION
**Fixing query selectors.*
* * *


# What does this Pull Request do?
This adds a wildcard to the querySelector for the divider since the number at the end seems to change. I also set up the querySelector to work similarly for the pager and the title since it is a nice ES6 way of doing things.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container using the delivery-type branch
* Confirm that the pager, divider and title do not show up for single images.
* Confirm that the pager, divider and title show up for paged items.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No 
- integration tests? No
