### PR TITLE
Updating plugins to 1.0.1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -642,8 +642,9 @@
       "license": "MIT"
     },
     "node_modules/@harvard-lts/mirador-help-plugin": {
-      "version": "1.0.0",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.0.1.tgz",
+      "integrity": "sha512-jkp3ZYJ4gEO3KL4fTxUzPxXIJxxSYQQ0iM/RH3C3icQVwDxeqcbzeqRLRvpfqIWRoF0jpCpZ0hdgFBSOkBqmPg==",
       "peerDependencies": {
         "mirador": "^3.3.0",
         "react": "16.x",
@@ -651,8 +652,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-hide-nav-plugin": {
-      "version": "1.0.0",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-hide-nav-plugin/-/mirador-hide-nav-plugin-1.0.1.tgz",
+      "integrity": "sha512-Ovh/R3GOcgHIs/qS5TRC1F+ONqUofb3/aaDuwcsS0jOH7jZ+i3izVvvK6JEVZIBNywVTRSCXC0brssEqW9FDKg==",
       "peerDependencies": {
         "mirador": "^3.3.0",
         "react": "16.x",
@@ -9665,11 +9667,15 @@
       "version": "0.8.0"
     },
     "@harvard-lts/mirador-help-plugin": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.0.1.tgz",
+      "integrity": "sha512-jkp3ZYJ4gEO3KL4fTxUzPxXIJxxSYQQ0iM/RH3C3icQVwDxeqcbzeqRLRvpfqIWRoF0jpCpZ0hdgFBSOkBqmPg==",
       "requires": {}
     },
     "@harvard-lts/mirador-hide-nav-plugin": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-hide-nav-plugin/-/mirador-hide-nav-plugin-1.0.1.tgz",
+      "integrity": "sha512-Ovh/R3GOcgHIs/qS5TRC1F+ONqUofb3/aaDuwcsS0jOH7jZ+i3izVvvK6JEVZIBNywVTRSCXC0brssEqW9FDKg==",
       "requires": {}
     },
     "@iiif/vocabulary": {


### PR DESCRIPTION
**Updating plugins to 1.0.1.**
* * *

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
As part of the on-call sprint, I upgraded node packages in our two custom plugins (mirador-help-plugin and mirador-hide-nav-plugin). This updates mps-viewer to use the latest versions of those plugins.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild mps-viewer using the `update-hide` branch
* Make sure you are also running mps-embed locally
* ssh into the container: `docker exec -it mps-viewer bash`
* Confirm version 1.0.1 of mirador-help-plugin is installed: `npm list @harvard-lts/mirador-help-plugin`
* Confirm version 1.0.1 of mirador-hide-nav-plugin is installed: `npm list @harvard-lts/mirador-hide-nav-plugin`
* Go to https://localhost:23017/
* Confirm that for single images the navigation does not show
* Confirm that the help modal still displays by clicking on the three dots in the top right corner of the viewer.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 