### PR TITLE
updating mirador-help-plugin to 1.0.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -642,9 +642,9 @@
       "license": "MIT"
     },
     "node_modules/@harvard-lts/mirador-help-plugin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.0.1.tgz",
-      "integrity": "sha512-jkp3ZYJ4gEO3KL4fTxUzPxXIJxxSYQQ0iM/RH3C3icQVwDxeqcbzeqRLRvpfqIWRoF0jpCpZ0hdgFBSOkBqmPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.0.2.tgz",
+      "integrity": "sha512-hcHMlqbyKsnPjEeflNukMWaBPafcLKcXF71V+QFAzqcqOCSoj9C1+lW+dzgw2YhE3YA0zL000lfP9XzVlCNIqQ==",
       "peerDependencies": {
         "mirador": "^3.3.0",
         "react": "16.x",
@@ -9667,9 +9667,9 @@
       "version": "0.8.0"
     },
     "@harvard-lts/mirador-help-plugin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.0.1.tgz",
-      "integrity": "sha512-jkp3ZYJ4gEO3KL4fTxUzPxXIJxxSYQQ0iM/RH3C3icQVwDxeqcbzeqRLRvpfqIWRoF0jpCpZ0hdgFBSOkBqmPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.0.2.tgz",
+      "integrity": "sha512-hcHMlqbyKsnPjEeflNukMWaBPafcLKcXF71V+QFAzqcqOCSoj9C1+lW+dzgw2YhE3YA0zL000lfP9XzVlCNIqQ==",
       "requires": {}
     },
     "@harvard-lts/mirador-hide-nav-plugin": {


### PR DESCRIPTION
**Updating mirador-help-plugin to 1.0.2..**
* * *

# What does this Pull Request do?
This updates the "report a problem" link in the help modal to use the proper URN.

# How should this be tested?

* Rebuild mps-viewer using the `update-report-link` branch
* Make sure you are also running mps-embed locally
* ssh into the container: `docker exec -it mps-viewer bash`
* Confirm version 1.0.2 of mirador-help-plugin is installed: `npm list @harvard-lts/mirador-help-plugin`
* Go to https://localhost:23017/
* Confirm the URN is used for the "Report a Problem" link in the Help modal.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 