### PR TITLE
Change named colour values to hex equivalent

### DIFF
--- a/src/mirador.js
+++ b/src/mirador.js
@@ -31,8 +31,8 @@ const config = {
         },
         secondary: {
           main: '#F8C21C',
-          dark: 'green',
-          contrastText: 'yellow'
+          dark: '##008000',
+          contrastText: '#ffff00'
         },
         error: {
           main: '#EB001B',
@@ -168,8 +168,8 @@ const config = {
         },
         secondary: {
           main: '#A51C30',
-          dark: 'green',
-          contrastText: 'yellow'
+          dark: '#008000',
+          contrastText: '#ffff00'
         },
         error: {
           main: '#EB001B',
@@ -229,7 +229,7 @@ const config = {
         },
         MuiPaper: {
           root: {
-            color: '##1E1E1E'
+            color: '#1E1E1E'
           }
         },
         MuiTypography: {


### PR DESCRIPTION

**JIRA Ticket**: [LTSVIEWER-180](https://jira.huit.harvard.edu/browse/LTSVIEWER-180)

# What does this Pull Request do?
Fixes an issue where when a manifest containing OCR is added to the viewer using the "Add resource" button results in an error message. The message says that 'Yellow' is not a valid colour option for a MUI component.

# How should this be tested?

- On QA test adding this manifest: https://mps-dev.lib.harvard.edu/iiif/3/URN-3:HUL.OIS:101114808 (OIS tunnel required)
- On this branch, try adding the same manifest — it should not display the error

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? N/A
- integration tests? N/A

# Interested parties
@ktamaral @enriquediaz 