### PR TITLE
Updating mirador-pdiif-plugin to 0.1.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@harvard-lts/mirador-help-plugin": "^1.0.2",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.3",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.4",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
         "bootstrap": "^5.2.3",
@@ -744,9 +744,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.3.tgz",
-      "integrity": "sha512-nuG6Hc6qsf1kKGbYgITvdOXpf6r/KX6KW2Wcbg+eoRJpSUyhfx+mM0/875iGcmPfDp+woGknZ05g4KLZ9KA/5Q==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.4.tgz",
+      "integrity": "sha512-OKNPt7aJW0WghPq/0nmFx4uJkDVFuKJdoI7Hxh/flENCTla9ikhFMnPFq3WieXe94ZIn6/oqMyN4bJv951GVZQ==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
@@ -10155,9 +10155,9 @@
       "requires": {}
     },
     "@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.3.tgz",
-      "integrity": "sha512-nuG6Hc6qsf1kKGbYgITvdOXpf6r/KX6KW2Wcbg+eoRJpSUyhfx+mM0/875iGcmPfDp+woGknZ05g4KLZ9KA/5Q==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.4.tgz",
+      "integrity": "sha512-OKNPt7aJW0WghPq/0nmFx4uJkDVFuKJdoI7Hxh/flENCTla9ikhFMnPFq3WieXe94ZIn6/oqMyN4bJv951GVZQ==",
       "requires": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.3",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.4",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",
     "bootstrap": "^5.2.3",


### PR DESCRIPTION
**Updating mirador-pdiif-plugin to 0.1.4.**
* * *

**JIRA Ticket**: [(LTSVIEWER-183)](https://jira.huit.harvard.edu/browse/LTSVIEWER-183)

# What does this Pull Request do?
This updates the concurrency used in the pdiif convertManifest API call from 1 to 4. This significantly speeds up large downloads. This works together with [the Pull Request in mirador-pdiiif-plugin](https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/3).

These changes have already been built to npmjs as **@harvard-lts/mirador-pdiiif-plugin 0.1.4**.

# How should this be tested?

A description of what steps someone could take to:
* Please see the speed differences I experienced in [this JIRA comment](https://jira.huit.harvard.edu/browse/LTSVIEWER-183?focusedCommentId=634865&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-634865). You should see something similar.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @jonw-cogapp @tristanr-cogapp @f8f8ff 