### PR TITLE
Add healthcheck executable

### DIFF
--- a/healthcheck
+++ b/healthcheck
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const http = require('http');
+const https = require('https');
+const URL = require('url').URL;
+ 
+const healthArguments = process.argv;
+var healthCheckURL;
+
+if (healthArguments.length === 2) { 
+    healthCheckURL = new URL(process.env.HEALTHCHECK_URL);
+}  else { 
+    healthCheckURL = new URL(healthArguments[2]);
+} 
+ 
+const healthCheckProtocol = healthCheckURL.protocol;
+const healthCheckURLReq = { 
+    host: healthCheckURL.hostname,
+    port: healthCheckURL.port,
+    path: healthCheckURL.pathname,
+    method: 'GET',
+    rejectUnauthorized: false,
+    requestCert: true,
+    agent: false
+  };
+ 
+ 
+let healthCheckResponse;
+function processResponse(res) { 
+    console.log(`HEALTHCHECK STATUS: ${res.statusCode}`);
+    if (res.statusCode == 200) {
+        process.exit(0);
+    }
+    else {
+        process.exit(1);
+    }
+};    
+ 
+if(healthCheckProtocol=='https:') {
+    healthCheckResponse = https.get(healthCheckURLReq, (res) => { 
+        processResponse(res) 
+    });
+} else { 
+    healthCheckResponse = http.get(healthCheckURLReq, (res) => {
+       processResponse(res);
+    });
+}
+ 
+healthCheckResponse.on('error', function (err) {
+    console.error('Error in Completing Health Check Request');
+    console.error(err);
+    process.exit(1);
+});
+ 
+healthCheckResponse.end(); 


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-157](https://jira.huit.harvard.edu/browse/LTSVIEWER-157)

# What does this Pull Request do?
Adds an executable which can be used instead of curl to verify that the healthcheck endpoint is reachable

# How should this be tested?
My understanding is that this will be used by CI in some way in the future. But to test this now locally, you should be able to verify that from project root directory (while the embed service is running):

From your host machine:
- Running `./healthcheck https://localhost:23017/healthcheck` => `HEALTHCHECK STATUS: 200`
- Running `./healthcheck https://localhost:23017/healthcheck-random-string` => `HEALTHCHECK STATUS: 404`

From the container (using `docker exec -it mps-viewer bash`):
- Running `./healthcheck https://mps-viewer:8081/healthcheck` => `HEALTHCHECK STATUS: 200`
- Running `./healthcheck https://mps-viewer:8081/healthcheck-random-string` => `HEALTHCHECK STATUS: 404`

While the service is not running, any of the host machine commands will return something like:

```
Error in Completing Health Check Request
Error: connect ECONNREFUSED 127.0.0.1:23017
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 23017
}
```
 
# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @ktamaral 