### PR TITLE
Make example items environment specific

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ docker-compose*
 !/logs/.keep
 public/js/dist/*
 !public/js/dist/.keep
+config/*
+!config/example-items-example.txt

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,7 @@ dist/*
 
 .idea/
 .DS_Store
+
+# Configuration
+/config/*
+!/config/example-items-example.txt

--- a/README.md
+++ b/README.md
@@ -31,7 +31,16 @@ Docker Compose
 
 *Note: The config file .env is specifically excluded in .gitignore and .dockerignore, since it contains credentials it should NOT ever be committed to any repository.*
 
-### 3: Start
+### 3: Create example items
+
+##### Create config file for environment variables
+- Make a copy of the example items example file `./config/example-items-example.txt`
+- Rename the file to `example-items.json`
+- Replace placeholder values as necessary
+
+*Note: The config file .example-items.json is specifically excluded in .gitignore and .dockerignore, since the examples will differ from environment to environment.*
+
+### 4: Start
 
 ##### START
 
@@ -41,7 +50,7 @@ This command builds all images and runs all containers specified in the docker-c
 docker-compose -f docker-compose-local.yml up -d --build --force-recreate
 ```
 
-### 4: SSH into Container (optional)
+### 5: SSH into Container (optional)
 
 ##### Run docker exec to execute a shell in the container by name
 
@@ -51,7 +60,7 @@ Open a shell using the exec command to access the mps-viewer container.
 docker exec -it mps-viewer bash
 ```
 
-### 5: Stop
+### 6: Stop
 
 ##### STOP AND REMOVE
 

--- a/config/example-items-example.txt
+++ b/config/example-items-example.txt
@@ -1,0 +1,22 @@
+{
+	"idsExamples": [{
+			"href": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
+			"text": "Harvard University Baseball Team, photograph, 1892"
+		},
+		{
+			"href": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
+			"text": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885"
+		},
+	],
+	"mpsExamples": [{
+			"href": "/example/mps/URN-3:DIV.LIB.USC:3200357?manifestVersion=2",
+			"text": "Harvard Divinity School Unitarian Service Committee",
+			"version": 2
+		},
+		{
+			"href": "/example/mps/URN-3:DIV.LIB.USC:3200357?manifestVersion=3",
+			"text": "Harvard Divinity School Unitarian Service Committee",
+			"version": 3
+		},
+	]
+}

--- a/controllers/examples.ctrl.js
+++ b/controllers/examples.ctrl.js
@@ -1,23 +1,15 @@
 const consoleLogger = require('../logger/logger.js').console;
-const fs = require('fs');
+const fsPromises = require('fs').promises;
 const path = require('path');
 
 const examplesCtrl = {};
 
 examplesCtrl.getExamples = async () => {
-    let examples;
-    fs.readFile(path.join(__dirname, '..', 'config', 'example-items.json'), 'utf8', function (err, data) {
-    if (err) throw err;
-    consoleLogger.info('DATA!');
-    consoleLogger.info(data);
-    //examples = await JSON.parse(data);
-    return JSON.parse(data);
-    });
+    
+    const data = await fsPromises.readFile(path.join(__dirname, '..', 'config', 'example-items.json'))
+        .catch((err) => console.error('Failed to read file', err));
 
-    //consoleLogger.info(path.join(__dirname, '..', 'config', 'example-items.json'));
-    //consoleLogger.info('EXAMPLES!');
-    //consoleLogger.info(examples);
-
+    return JSON.parse(data.toString());
 };
 
 module.exports = examplesCtrl;

--- a/controllers/examples.ctrl.js
+++ b/controllers/examples.ctrl.js
@@ -1,0 +1,23 @@
+const consoleLogger = require('../logger/logger.js').console;
+const fs = require('fs');
+const path = require('path');
+
+const examplesCtrl = {};
+
+examplesCtrl.getExamples = async () => {
+    let examples;
+    fs.readFile(path.join(__dirname, '..', 'config', 'example-items.json'), 'utf8', function (err, data) {
+    if (err) throw err;
+    consoleLogger.info('DATA!');
+    consoleLogger.info(data);
+    //examples = await JSON.parse(data);
+    return JSON.parse(data);
+    });
+
+    //consoleLogger.info(path.join(__dirname, '..', 'config', 'example-items.json'));
+    //consoleLogger.info('EXAMPLES!');
+    //consoleLogger.info(examples);
+
+};
+
+module.exports = examplesCtrl;

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -15,6 +15,7 @@ services:
       - './:/home/mpsadm'
       - '/home/mpsadm/node_modules'
       - '/home/mpsadm/public/js/dist'
+      - './config/example-items.json:/home/mpsadm/config/example-items.json:ro'
     ports:
       - "23017:8081"
     # Join this service to a custom docker network

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,72 +2,12 @@ const express = require('express');
 const router = express.Router();
 const embedCtrl = require('../controllers/embed.ctrl');
 const consoleLogger = require('../logger/logger.js').console;
+const exampleItems = require('../config/example-items.json');
 
 router.get("/", async (req, res) => {
 
-  const idsExamples = [
-    {
-      "href": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
-      "text": "Harvard University Baseball Team, photograph, 1892"
-    },
-    {
-      "href": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
-      "text": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885"
-    },
-    {
-      "href": "/example/legacy/W587091_URN-3:RAD.SCHL:11680642",
-      "text": "To roast a chicken; show #217"
-    },
-    {
-      "href": "/example/legacy/HUAM140429_URN-3:HUAM:INV012574P_DYNMC",
-      "text": "Untitled Drumset"
-    },
-    {
-      "href": "/example/legacy/990100671200203941",
-      "text": "Hot Dog In The Manger"
-    },
-    {
-      "href": "/example/legacy/990095204340203941",
-      "text": "Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass."
-    },
-    {
-      "href": "/example/legacy/990098789400203941",
-      "text": "Heures de Nôtre Dame (use of Troyes and Sens) : manuscript, [ca. 1470]"
-    }
-  ];
-
-  const mpsExamples = [
-    {
-      "href": "/example/mps/URN-3:DIV.LIB.USC:3200357?manifestVersion=2",
-      "text": "Harvard Divinity School Unitarian Service Committee",
-      "version": 2
-    },
-    {
-      "href": "/example/mps/URN-3:DIV.LIB.USC:3200357?manifestVersion=3",
-      "text": "Harvard Divinity School Unitarian Service Committee",
-      "version": 3
-    },
-    {
-      "href": "/example/mps/URN-3:FHCL:42632611?manifestVersion=2",
-      "text": "Harvard Yenching Fushun Xian zhi 37 juan",
-      "version": 2
-    },
-    {
-      "href": "/example/mps/URN-3:FHCL:42632611?manifestVersion=3",
-      "text": "Harvard Yenching Fushun Xian zhi 37 juan",
-      "version": 3
-    },
-    {
-      "href": "/example/mps/URN-3:FHCL:100001249?manifestVersion=2",
-      "text": "Tibetan Buddhist Resource Center",
-      "version": 2
-    },
-    {
-      "href": "/example/mps/URN-3:FHCL:100001249?manifestVersion=2",
-      "text": "Tibetan Buddhist Resource Center",
-      "version": 3
-    }
-  ];
+  const idsExamples = exampleItems.idsExamples;
+  const mpsExamples = exampleItems.mpsExamples;
 
   res.render("index", {
     title: "Welcome to the MPS Viewer!",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,10 +1,19 @@
 const express = require('express');
 const router = express.Router();
 const embedCtrl = require('../controllers/embed.ctrl');
+const examplesCtrl = require('../controllers/examples.ctrl');
 const consoleLogger = require('../logger/logger.js').console;
 const exampleItems = require('../config/example-items.json');
 
 router.get("/", async (req, res) => {
+
+  try {
+    examples = await examplesCtrl.getExamples();
+  } catch(e) {
+    consoleLogger.error(e);
+  }
+  consoleLogger.debug('EXAMPLES: '+examples);
+
 
   const idsExamples = exampleItems.idsExamples;
   const mpsExamples = exampleItems.mpsExamples;

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,17 +3,15 @@ const router = express.Router();
 const embedCtrl = require('../controllers/embed.ctrl');
 const examplesCtrl = require('../controllers/examples.ctrl');
 const consoleLogger = require('../logger/logger.js').console;
-const exampleItems = require('../config/example-items.json');
 
 router.get("/", async (req, res) => {
 
+  let exampleItems;
   try {
-    examples = await examplesCtrl.getExamples();
+    exampleItems = await examplesCtrl.getExamples();
   } catch(e) {
     consoleLogger.error(e);
   }
-  consoleLogger.debug('EXAMPLES: '+examples);
-
 
   const idsExamples = exampleItems.idsExamples;
   const mpsExamples = exampleItems.mpsExamples;


### PR DESCRIPTION
**Make example items environment specific.**
* * *

**JIRA Ticket**: [LTSVIEWER-184](https://jira.huit.harvard.edu/browse/LTSVIEWER-184)

# What does this Pull Request do?
This updates the index page to use an external json file to determine what shows up in both the IDS and MPS examples list. You need to manually add the `config/example-items.json` file to your filesystem before spinning up the containers. Also note the new variables in the .env file to determine what environment it will use for MPS.

I have attached 3 files in a zip file to this PR that you can use for each environment.
[ExampleItems.zip](https://github.com/harvard-lts/mps-viewer/files/11547403/ExampleItems.zip)

# How should this be tested?

A description of what steps someone could take to:
* Unzip the `ExampleItems.zip` file attached to this PR.
* Rename `example-items-dev.json` to `example-items.json`
* Add the following variable to the `.env` for **MPS-EMBED**: `MPS_MANIFEST_BASEURL=https://mps-dev.lib.harvard.edu/iiif`
* Start up both the **MPS-EMBED** and **MPS-VIEWER** containers
* You should see the examples in the json file showing up on the index page of your local Viewer. The MPS manifests should resolve to items on the Dev MPS environment.
* You can repeat the same steps for QA and Prod using the appropriate .json files and by changing the `MPS_MANIFEST_BASEURL` to `https://mps-qa.lib.harvard.edu/iiif` or `https://mps.lib.harvard.edu/iiif`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? no

# Interested parties
@f8f8ff @enriquediaz @tristanr-cogapp 