### PR TITLE
Update PDIIIF plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@harvard-lts/mirador-help-plugin": "^1.0.2",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.7",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.8",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -745,14 +745,14 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.7.tgz",
-      "integrity": "sha512-xrlJA8x6WJ4NWji2kimDZaMadJjs3Lpskd3rcf0bUM9O0zu9nNxGfANkYqGw5s/So2D7PVpfpqRLkfd1AOV4xQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.8.tgz",
+      "integrity": "sha512-5khm14Ie4XYQJN7Gkehc9ZNa4jF1Q+JAUf/eNn3QwrpGWKm11z2msJr7z3TZ36cA2158EV3SOQx3HK1XzHetjA==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "mirador": "^3.3.0",
-        "pdiiif": "^0.1.0",
+        "pdiiif": "^0.1.2",
         "prop-types": "^15.8.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
@@ -6654,11 +6654,6 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/logform": {
       "version": "2.4.0",
       "license": "MIT",
@@ -7391,9 +7386,9 @@
       "version": "0.0.1"
     },
     "node_modules/pdiiif": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pdiiif/-/pdiiif-0.1.0.tgz",
-      "integrity": "sha512-U9aw66nUxzTczj2rFoe4nPRFmdhx+eQxnpEEzK/S67+/dhOmvOhm+UxQZ0fxpIfxq5+JgcYAPyV2xxJnLRwoPg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pdiiif/-/pdiiif-0.1.2.tgz",
+      "integrity": "sha512-hB7VydBR5P6WNQEcea4cikD3RC6vmZpBHn39oldBbYS8FJgLrqxGN6FyMa7oUb00dO6pAC4AGbEZetbffmRjcQ==",
       "dependencies": {
         "@atlas-viewer/iiif-image-api": "^2.1.1",
         "@iiif/parser": "^1.1.2",
@@ -7408,7 +7403,6 @@
         "dompurify": "^3.0.0",
         "fflate": "^0.7.4",
         "jsdom": "^21.1.0",
-        "lodash-es": "^4.17.21",
         "p-queue": "7.3.0",
         "path-data-polyfill": "^1.0.4",
         "prom-client": "^14.1.1",
@@ -10193,14 +10187,14 @@
       "requires": {}
     },
     "@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.7.tgz",
-      "integrity": "sha512-xrlJA8x6WJ4NWji2kimDZaMadJjs3Lpskd3rcf0bUM9O0zu9nNxGfANkYqGw5s/So2D7PVpfpqRLkfd1AOV4xQ==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.8.tgz",
+      "integrity": "sha512-5khm14Ie4XYQJN7Gkehc9ZNa4jF1Q+JAUf/eNn3QwrpGWKm11z2msJr7z3TZ36cA2158EV3SOQx3HK1XzHetjA==",
       "requires": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "mirador": "^3.3.0",
-        "pdiiif": "^0.1.0",
+        "pdiiif": "^0.1.2",
         "prop-types": "^15.8.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
@@ -14490,11 +14484,6 @@
     "lodash": {
       "version": "4.17.21"
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "logform": {
       "version": "2.4.0",
       "requires": {
@@ -14978,9 +14967,9 @@
       "version": "0.0.1"
     },
     "pdiiif": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/pdiiif/-/pdiiif-0.1.0.tgz",
-      "integrity": "sha512-U9aw66nUxzTczj2rFoe4nPRFmdhx+eQxnpEEzK/S67+/dhOmvOhm+UxQZ0fxpIfxq5+JgcYAPyV2xxJnLRwoPg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pdiiif/-/pdiiif-0.1.2.tgz",
+      "integrity": "sha512-hB7VydBR5P6WNQEcea4cikD3RC6vmZpBHn39oldBbYS8FJgLrqxGN6FyMa7oUb00dO6pAC4AGbEZetbffmRjcQ==",
       "requires": {
         "@atlas-viewer/iiif-image-api": "^2.1.1",
         "@iiif/parser": "^1.1.2",
@@ -14995,7 +14984,6 @@
         "dompurify": "^3.0.0",
         "fflate": "^0.7.4",
         "jsdom": "^21.1.0",
-        "lodash-es": "^4.17.21",
         "p-queue": "7.3.0",
         "path-data-polyfill": "^1.0.4",
         "prom-client": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.7",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.8",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-185](https://jira.huit.harvard.edu/browse/LTSVIEWER-185)

# What does this Pull Request do?
Updates the PDIIIF plugin dependency to include the latest version of PDIIIF, which fixes the duplication in the table of contents 

# How should this be tested?

- Checkout this branch
- Restart the viewer Docker container
- (I also had to manually shell into the container and re-run webpack, but this _shouldn't_ be necessary)
- Try to generate a PDF where we've observed ToC duplication
- The expected outcome is that the ToC items are no longer duplicated

If you needed to manually run webpack, we should consider why this was necessary. Maybe some kind of cache is involved? 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? N/A
- integration tests? N/A

# Interested parties
@enriquediaz @tristanr-cogapp 