### PR TITLE
Add configurable coverpage endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@harvard-lts/mirador-help-plugin": "^1.0.2",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.17",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.18",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.17.tgz",
-      "integrity": "sha512-Pz52PcQGSpMZMTgb8QS6y5oJwqXLUNTal+nxk9mVTaAMaoSwONs7M3WzzfLFILcoEhkHJjdzk5l5yg4qrdUINw==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.18.tgz",
+      "integrity": "sha512-NIdOPf6fO+TklX11OofV3DdvpxDw4r4wEiCzxC035O5XxbnFgjAL8fEHe9WZpQ5OA39oK6BEs9ahs3YaIqF4ug==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
@@ -10075,9 +10075,9 @@
       "requires": {}
     },
     "@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.17.tgz",
-      "integrity": "sha512-Pz52PcQGSpMZMTgb8QS6y5oJwqXLUNTal+nxk9mVTaAMaoSwONs7M3WzzfLFILcoEhkHJjdzk5l5yg4qrdUINw==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.18.tgz",
+      "integrity": "sha512-NIdOPf6fO+TklX11OofV3DdvpxDw4r4wEiCzxC035O5XxbnFgjAL8fEHe9WZpQ5OA39oK6BEs9ahs3YaIqF4ug==",
       "requires": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.17",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.18",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-158](https://jira.huit.harvard.edu/browse/LTSVIEWER-158)

- [Harvard LTS PDIIIF companion PR](https://github.com/harvard-lts/pdiiif/pull/1)
- [PDIIIF Mirador Plugin companion PR](https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/8)

# What does this Pull Request do?
Updates PDIIIF Mirador Plugin to a version which allows the coverpage API endpoint to be passed in as config.

# How should this be tested?

- Refer to the testing instructions in the [Harvard LTS PDIIIF repository](https://github.com/harvard-lts/pdiiif/pull/1)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 