### PR TITLE
Update PDIIIF to lower chara limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@harvard-lts/mirador-help-plugin": "^1.0.2",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.18",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.21",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.18.tgz",
-      "integrity": "sha512-NIdOPf6fO+TklX11OofV3DdvpxDw4r4wEiCzxC035O5XxbnFgjAL8fEHe9WZpQ5OA39oK6BEs9ahs3YaIqF4ug==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.21.tgz",
+      "integrity": "sha512-OvCc+XJNIuvQsNjaLKL6+O3ACFl5kB4SI30PkN3b0yIk+NoB/BWKtMzs/kraTjAy1w/nnYjB2vqppcOstZ9uXQ==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
@@ -10075,9 +10075,9 @@
       "requires": {}
     },
     "@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.18.tgz",
-      "integrity": "sha512-NIdOPf6fO+TklX11OofV3DdvpxDw4r4wEiCzxC035O5XxbnFgjAL8fEHe9WZpQ5OA39oK6BEs9ahs3YaIqF4ug==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.21.tgz",
+      "integrity": "sha512-OvCc+XJNIuvQsNjaLKL6+O3ACFl5kB4SI30PkN3b0yIk+NoB/BWKtMzs/kraTjAy1w/nnYjB2vqppcOstZ9uXQ==",
       "requires": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.18",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.21",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**JIRA Ticket**: LTSVIEWER-197

- [PDIIIF mirador plugin companion PR](https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/9)

# What does this Pull Request do?
Updates the PDIIIF mirador plugin version to lower the acceptable suggested file name length.

# How should this be tested?

- See the [companion PR](https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/9) for full test instructions

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No
