### PR TITLE
Update docs about workflow and publishing plugins

### DIFF
--- a/docs/developing-mirador-plugins.md
+++ b/docs/developing-mirador-plugins.md
@@ -10,18 +10,18 @@ Additionally there are certain things we should avoid in our work today due to k
 | --- | --- | --- |
 | [NWB](https://github.com/insin/nwb) | NWB isn't actively maintained, it requires an old version of node in order to work and might have compatibility issues with React Testing Library. It seems like Mirador will be moving away from this eventually | ~[Parcel](https://github.com/parcel-bundler/parcel)~, [vite](https://github.com/vitejs/vite), [Webpack](https://github.com/webpack/webpack) (community consensus TBD) |
 | [Enzyme](https://github.com/enzymejs/enzyme) | Enzyme isn't actively maintained, and doesn't support React versions newer than 16. Mirador has already begun moving away from this | [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) |
-| [Parcel](https://github.com/parcel-bundler/parcel) | Occassionally seemed to create errors during the course of development and made progress more difficult | [Webpack](https://github.com/webpack/webpack) and [Rollup](https://rollupjs.org) |
+| [Parcel](https://github.com/parcel-bundler/parcel) | Occasionally seemed to create errors during the course of development and made progress more difficult | [Webpack](https://github.com/webpack/webpack) and [Rollup](https://rollupjs.org) |
 
 
 ## Suggested workflow for Mirador plugins
 
 1. Create a repository for the plugin
 2. Create a feature branch named corresponding to the Jira ticket
-3. Follow the the [PDIIIF plugin as an example](https://github.com/harvard-lts/mirador-pdiiif-plugin). You should be able to take its `package.json` file and swap its metadata (`name`, `description`, `version`, `repository`, and `dependencies`) for your own
+3. Follow the [PDIIIF plugin as an example](https://github.com/harvard-lts/mirador-pdiiif-plugin), taking all of it's config. You should be able to modify its `package.json` file and swap its metadata (`name`, `description`, `version`, `repository`, and `dependencies`) for your own.  
 4. Make sure you have an `src/index.js`, which exports your plugin as an array in the default export
 5. Work on your code locally using the [recommended local development strategy](#run-the-plugin-using-webpack-dev-server-recommended)
 6. When your code is ready for review, follow the standard procedure for code reviews and PR's 
-7. See the section on publishing to NPM
+7. **After** the PR is merged, see the section on publishing to NPM
 8. Create a PR for mps-viewer which updates the package.json to include your plugin at the correct version number (make sure to run `npm i` in the container to update the `package-lock.json`, too).
 9. Add the plugin to the list of [Custom Harvard Mirador Plugins](./custom-harvard-mirador-plugins.md)
 
@@ -35,7 +35,7 @@ This solution will allow you to develop the plugin against a stock version of Mi
 
 If your plugin is using the [suggested workflow](#suggested-workflow-for-mirador-plugins), then you can run the dev server by running `npm run serve`.
 
-### Shimming into Mirador (not recommmended)
+### Shimming into Mirador (not recommended)
 
 Shimming a plugin into Mirador will allow you to have full access to React and Redux devtools and can help to debug your code. The process looks something like this:
 
@@ -77,6 +77,23 @@ It's a bit more straightforward to shim a plugin into MPS, the steps are somethi
 2. Import your plugin to `src/mirador.js` and include it in the plugins array
 
 
+## Publishing to NPM
+### Setup
+
+If your package doesn't exist on NPM yet, you'll need to [publish it manually](https://docs.npmjs.com/packages-and-modules). Afterwards publishing should be left to CI.
+
+Publishing to NPM is handled by a Github Actions workflow. In order to use the workflow you'll need:
+
+1. To follow [the suggested workflow](#suggested-workflow-for-mirador-plugins)
+2. An [NPM granular access token](https://docs.npmjs.com/about-access-tokens#about-granular-access-tokens), which provides granular *read/write* access to the package on [npmjs.com](https://npmjs.com/packages-and-modules). This must be stored in a secret in the repository named `NPM_ACCESS_TOKEN`.
+3. A [Github Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) that provides granular *read/write* access to the "_contents_" on this repository. This must be stored in a secret in the repository named `ACCESS_TOKEN`.
+
+### Publishing via Github
+
+Draft a new release in the Github UI and create a tag for the version number that you'd like to publish to NPM. Do this for the `main` branch (after the feature has been merged). When the action completes the version published to NPM will match the tag used when creating the release.  
+
+In the unlikely event the action fails, you'll probably want to delete the release and the tag (in that order), debug the errors and then try again.
+
 
 ## Troubleshooting
 
@@ -90,6 +107,15 @@ Some problem scenarios that have been observed before along with possible soluti
         </tr>
     </thead>
     <tbody>
+        <tr>
+            <td>The action to publish to NPM when creating a release fails</td>
+            <td>
+                <ul>
+                    <li>Make sure the appropriate secrets are set and that the access tokens have the correct permissions and haven't expired.</li>
+                    <li>Check `/actions` in Github for more details to help debug the issue</li>
+                </ul>
+            </td>
+        </tr>    
         <tr>
             <td>Shimming the plug-in works, but including it via `node_modules` throws an error. Parcel appears to produce a bundle which doesn't include one or more of the imports correctly</td>
             <td>

--- a/docs/developing-mirador-plugins.md
+++ b/docs/developing-mirador-plugins.md
@@ -8,28 +8,34 @@ Additionally there are certain things we should avoid in our work today due to k
 
 | Avoid | Reason | Prefer |
 | --- | --- | --- |
-| [NWB](https://github.com/insin/nwb) | NWB isn't actively maintained, it requires an old version of node in order to work and might have compatibility issues with React Testing Library. It seems like Mirador will be moving away from this eventually | [Parcel](https://github.com/parcel-bundler/parcel), [vite](https://github.com/vitejs/vite), [webpack](https://github.com/webpack/webpack) (community consensus TBD) |
+| [NWB](https://github.com/insin/nwb) | NWB isn't actively maintained, it requires an old version of node in order to work and might have compatibility issues with React Testing Library. It seems like Mirador will be moving away from this eventually | ~[Parcel](https://github.com/parcel-bundler/parcel)~, [vite](https://github.com/vitejs/vite), [Webpack](https://github.com/webpack/webpack) (community consensus TBD) |
 | [Enzyme](https://github.com/enzymejs/enzyme) | Enzyme isn't actively maintained, and doesn't support React versions newer than 16. Mirador has already begun moving away from this | [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) |
+| [Parcel](https://github.com/parcel-bundler/parcel) | Occassionally seemed to create errors during the course of development and made progress more difficult | [Webpack](https://github.com/webpack/webpack) and [Rollup](https://rollupjs.org) |
 
 
 ## Suggested workflow for Mirador plugins
 
-1. Make new branch in mps-viewer named corresponding to the Jira ticket
-2. Begin by shimming the plugin into MPS viewer or Mirador (see below for detailed instructions)
-3. Once you're happy with the results, create an empty repo for the plugin (the general convention is `mirador-<name>-plugin`)
-4. Create a branch on the plugin repo named with the corresponding Jira ticket and migrate your plugin code here and write tests if possible (This step will ensure your code be reviewed more easily, as you'll be able to make a PR)
-5. Publish the plugin to npm on the `@harvard-lts` organization
-6. Update MPS Viewer to install and include the npm module proper
-7. Create two PR's, one for mps-viewer, the other for the plugin. Have testing instructions in one of these PR's and have them reference each other
-8. Add the plugin to the list of [Custom Harvard Mirador Plugins](./custom-harvard-mirador-plugins.md)
-
+1. Create a repository for the plugin
+2. Create a feature branch named corresponding to the Jira ticket
+3. Follow the the [PDIIIF plugin as an example](https://github.com/harvard-lts/mirador-pdiiif-plugin). You should be able to take its `package.json` file and swap its metadata (`name`, `description`, `version`, `repository`, and `dependencies`) for your own
+4. Make sure you have an `src/index.js`, which exports your plugin as an array in the default export
+5. Work on your code locally using the [recommended local development strategy](#run-the-plugin-using-webpack-dev-server-recommended)
+6. When your code is ready for review, follow the standard procedure for code reviews and PR's 
+7. See the section on publishing to NPM
+8. Create a PR for mps-viewer which updates the package.json to include your plugin at the correct version number (make sure to run `npm i` in the container to update the `package-lock.json`, too).
+9. Add the plugin to the list of [Custom Harvard Mirador Plugins](./custom-harvard-mirador-plugins.md)
 
 ## Local development
 
 Working in Docker comes with the unfortunate drawback that using `npm link` to substitute a dependency for a local one doesn't really work as well. There may be better ways to do this, but in the meantime here's some suggestions for developing and debugging your code locally.
 
+### Run the plugin using Webpack dev-server (recommended)
 
-### Shimming into Mirador
+This solution will allow you to develop the plugin against a stock version of Mirador. It grants you full access to the React and Redux dev tools, and will auto-compile and reload the browser window when the `src` files are updated.
+
+If your plugin is using the [suggested workflow](#suggested-workflow-for-mirador-plugins), then you can run the dev server by running `npm run serve`.
+
+### Shimming into Mirador (not recommmended)
 
 Shimming a plugin into Mirador will allow you to have full access to React and Redux devtools and can help to debug your code. The process looks something like this:
 
@@ -63,7 +69,7 @@ Shimming a plugin into Mirador will allow you to have full access to React and R
 5. Run `npm run start` to get the local dev server running
 
 
-### Shimming into MPS Viewer
+### Shimming into MPS Viewer (not recommended)
 
 It's a bit more straightforward to shim a plugin into MPS, the steps are something like:
 
@@ -90,6 +96,7 @@ Some problem scenarios that have been observed before along with possible soluti
                 <ul>
                     <li>Make sure that all the dependencies are installed (using `npm install` if any new were added) in the plugin repo.</li>
                     <li>Try running `npm update parcel` in the plugin repo</li>
+                    <li>Switch to using Rollup and Webpack, following the [PDIIIF plugin as a guide](https://github.com/harvard-lts/mirador-pdiiif-plugin)</li>
                 </ul>
             </td>
         </tr>
@@ -149,7 +156,7 @@ We've created some plugins that do various things. Here are some you might find 
         <td><a href="https://github.com/harvard-lts/mirador-pdiiif-plugin">PDIIIF plugin</a></td>
         <td>
             <ul>
-                <li>Shows tooling without NWB (Parcel, for now)</li>
+                <li>Shows tooling without NWB, using Rollup + Webpack</li>
                 <li>Shows tests written using React Testing Library</li>
             </ul>
         </td>            

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@harvard-lts/mirador-help-plugin": "^1.0.2",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.22",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.24",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -745,13 +745,12 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.22.tgz",
-      "integrity": "sha512-IKT0Lf97LFAYio2JUMfvdTdKyunVIAfccT7shVhVA8wqtDUDrqyXczuCC2/r6KXLdUcLUthQYQtQoTN8VYW3/A==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.24.tgz",
+      "integrity": "sha512-UOpHfl/o4BenOpNpI/wQyrm6VfcCshwyd5u0SMBkL0sXLWMBqyXC8opPVz0cRA9P4frhcbIiu+P2UhXa/kWwYg==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
-        "mirador": "^3.3.0",
         "pdiiif": "^0.1.5",
         "prop-types": "^15.8.1",
         "react": "^16.14.0",
@@ -10075,13 +10074,12 @@
       "requires": {}
     },
     "@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.22.tgz",
-      "integrity": "sha512-IKT0Lf97LFAYio2JUMfvdTdKyunVIAfccT7shVhVA8wqtDUDrqyXczuCC2/r6KXLdUcLUthQYQtQoTN8VYW3/A==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.24.tgz",
+      "integrity": "sha512-UOpHfl/o4BenOpNpI/wQyrm6VfcCshwyd5u0SMBkL0sXLWMBqyXC8opPVz0cRA9P4frhcbIiu+P2UhXa/kWwYg==",
       "requires": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
-        "mirador": "^3.3.0",
         "pdiiif": "^0.1.5",
         "prop-types": "^15.8.1",
         "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.22",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.24",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-228](https://jira.huit.harvard.edu/browse/LTSVIEWER-228)

- [PR for PDIIIF plugin](https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/12)

# What does this Pull Request do?
Updates documentation to cover recent updates and improvements into the workflow for the PDIIIF plugin. Some of this overlaps with the plugin linked above.

It also includes a version update for the PDIIIF plugin which was generated with the new workflow.

# How should this be tested?
- Check the documentation for errors
- Check the plugin works with the included version

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 