### PR TITLE
Adding ability to switch between pdiiif endpoints.

### DIFF
--- a/env-example.txt
+++ b/env-example.txt
@@ -6,3 +6,6 @@ EMBED_BASE_URL=https://<your IPV4 address>:23018
 
 # Set this to 'false' for local testing. Set to 'true' for other environments
 HTTPS_REJECT_UNAUTHORIZED=false
+
+# Determine what pdiiif coverpage endpoint to use
+PDIIIF_COVERPAGE_ENDPOINT=http://localhost:8080/api/coverpage

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@babel/preset-react": "^7.18.6",
         "babel-loader": "^9.1.2",
         "clean-webpack-plugin": "^4.0.0",
+        "dotenv-webpack": "^8.0.1",
         "jest": "^29.5.0",
         "nodemon": "^2.0.22",
         "supertest": "^6.3.3"
@@ -3223,6 +3224,39 @@
     "node_modules/dompurify": {
       "version": "2.3.6",
       "license": "(MPL-2.0 OR Apache-2.0)"
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dev": true,
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -11177,6 +11211,30 @@
     },
     "dompurify": {
       "version": "2.3.6"
+    },
+    "dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true
+    },
+    "dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dev": true,
+      "requires": {
+        "dotenv-defaults": "^2.0.2"
+      }
     },
     "ee-first": {
       "version": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "test:integration": "./node_modules/.bin/jest --testPathPattern=__tests__/integration"
   },
   "dependencies": {
+    "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
     "@harvard-lts/mirador-pdiiif-plugin": "^0.1.24",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
-    "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",
     "bootstrap": "^5.2.3",
@@ -56,6 +56,7 @@
     "@babel/preset-react": "^7.18.6",
     "babel-loader": "^9.1.2",
     "clean-webpack-plugin": "^4.0.0",
+    "dotenv-webpack": "^8.0.1",
     "jest": "^29.5.0",
     "nodemon": "^2.0.22",
     "supertest": "^6.3.3"

--- a/src/mirador.js
+++ b/src/mirador.js
@@ -343,6 +343,7 @@ const config = {
     // If it's an iframe embedded elsewhere, it will need the origin from frameElement.src
     // If it's viewed directly it will need origin from the address bar
     mitmPath: `${new URL(window?.frameElement?.src ?? window.origin).origin}/pdiiif/mitm.html`,
+    coverPageEndpoint: process.env.PDIIIF_COVERPAGE_ENDPOINT,
   },
   miradorAnalyticsPlugin: {
     containerId:'GTM-WSHSDQ5',

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
   mode: 'development',
@@ -30,6 +30,7 @@ module.exports = {
     new webpack.IgnorePlugin({
       resourceRegExp: /@blueprintjs\/(core|icons)/, // ignore optional UI framework dependencies
     }),
+    new Dotenv(),
   ],
   /*optimization: {
     minimize: false


### PR DESCRIPTION
**Adding ability to switch between pdiiif endpoints.**
* * *

**JIRA Ticket**: [LTSVIEWER-221](https://jira.huit.harvard.edu/browse/LTSVIEWER-221)

# What does this Pull Request do?
This updates the application to use a new .env variable called `PDIIIF_COVERPAGE_ENDPOINT` to determine which pdiiif endpoint to use for generating the coverpages.

# How should this be tested?

A description of what steps someone could take to:
* Add the new `PDIIIF_COVERPAGE_ENDPOINT` variable to your local `.env` file.
* Dev value of the endpoint is: https://pdiiif-dev.lib.harvard.edu/api/coverpage
* QA value of the endpoint is: https://pdiiif-qa.lib.harvard.edu/api/coverpage 
* Rebuild the container using the `LTSVIEWER-221b` branch
* Go to any item and download the PDF
* If you inspect the network you should see that it uses whatever endpoint you set in the `.env` to create the coverpage (see example screenshot below)
* The coverpage will not have the Harvard Shield, IIIF Logo or QR code (these are customizations made to the coverpage previously by Jon to determine it is "Working")
* If you do not define `PDIIIF_COVERPAGE_ENDPOINT` in your `.env` file it will fall back to using https://pdiiif.jbaiter.de/

![CoverpageNetwork](https://github.com/harvard-lts/mps-viewer/assets/40801910/dc96aca3-50a9-4c54-a7aa-21184175696f)

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 