### PR TITLE
Moving webpack to entrypoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,12 @@ RUN echo 'umask 002' >> /home/${APP_ID_NAME}/.profile && \
 WORKDIR /home/${APP_ID_NAME}
 COPY . /home/${APP_ID_NAME}
 
-RUN npm install && npm run webpack
+RUN npm install
+
+RUN chmod 754 /home/${APP_ID_NAME}/bin/webpack.sh
 
 USER ${APP_ID_NAME}
+
+ENTRYPOINT ["bin/webpack.sh"]
 
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN echo 'umask 002' >> /home/${APP_ID_NAME}/.profile && \
   echo 'umask 002' >> /home/${APP_ID_NAME}/.bashrc
 
 WORKDIR /home/${APP_ID_NAME}
-COPY . /home/${APP_ID_NAME}
+COPY --chown=${APP_ID_NAME}:${GROUP_ID_NAME} . /home/${APP_ID_NAME}
 
 RUN npm install
 

--- a/bin/webpack.sh
+++ b/bin/webpack.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#This script forces webpack to be run.
+
+set -e
+
+npm run webpack
+
+exec "$@"

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -14,7 +14,6 @@ services:
     volumes:
       - './:/home/mpsadm'
       - '/home/mpsadm/node_modules'
-      - '/home/mpsadm/public/js/dist'
       - './config/example-items.json:/home/mpsadm/config/example-items.json:ro'
     ports:
       - "23017:8081"


### PR DESCRIPTION
**Moving webpack to entrypoint.**
* * *

**JIRA Ticket**: [LTSVIEWER-239](https://jira.huit.harvard.edu/browse/LTSVIEWER-239)

# What does this Pull Request do?
This moves webpack from being run as root as the same time as npm install to being run by the mpsadmin user everytime the container is restarted. This will allow the LTS cloud environments to use the .env variable to switch coverpage endpoints.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container from the `LTSVIEWER-239` branch
* Confirm that webpack ran successfully after the container was build (`docker logs -f mps-viewer`)
* Take the container down: docker-compose -f docker-compose-local.yml down 
* Bring the container back up (without rebuilding): docker-compose -f docker-compose-local.yml up -d
* Confirm that webpack ran successfully again (`docker logs -f mps-viewer`)
* When you bring the container down,switch the `PDIIIF_COVERPAGE_ENDPOINT` variable in `.env` and bring it back up. You should see that the coverpage is built using the new endpoint (Instructions for this in this PR: https://github.com/harvard-lts/mps-viewer/pull/60)
* Bash into the container as a non-root user and confirm you can run webpack: `docker exec -it mps-viewer bash` then `npm run webpack`
* 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 