### PR TITLE
Update Harvard shield for accessibility

### DIFF
--- a/plugins/harvard_branding.js
+++ b/plugins/harvard_branding.js
@@ -5,12 +5,7 @@ class harvardBranding extends Component {
     return (
         <div class="WithPlugins(WorkspaceControlPanel)-branding-2">
             <p class="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter">
-                <a class="MuiButtonBase-root MuiIconButton-root" tabindex="0" aria-disabled="false" href="https://library.harvard.edu/" target="_blank" rel="noopener">
-                    <span class="MuiIconButton-label">
-                        <img src="/images/shield_small_crimson.png" width="100%"></img>
-                    </span>
-                    <span class="MuiTouchRipple-root"></span>
-                </a>
+              <img src="/images/shield_small_crimson.png" alt="" height="40px" width="40px"></img>
             </p>
         </div>
     );


### PR DESCRIPTION
**Update Harvard shield for accessibility**
* * *

**JIRA Ticket**: [LTSVIEWER-229](https://jira.huit.harvard.edu/browse/LTSVIEWER-229)

# What does this Pull Request do?
Removed link and added a blank alt-text tag to the Harvard shield so that Viewer is compliant with accessibility standards and more generic for use across the university

# How should this be tested?
* Spin up Viewer from this branch
* Inspect the Harvard shield in the lower left corner of Viewer; you should notice that the image has a blank alt-text tag (alt="") and that it is no longer enclosed by a link tag
* Tab through the page; since the shield is no longer a link, it should be skipped when tabbing
* On a mac, open up voiceover and head to the rotor view (CMD+OPT+U); the shield should not show up in the links window as an option

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 