### PR TITLE
Adding community mirador plugins to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Docker Compose
         * [Unofficial docs](docs/developing-mirador-plugins.md#unofficial-docs)
         * [Existing harvard plugins](docs/developing-mirador-plugins.md#existing-harvard-plugins)
         * [Extra reading](docs/developing-mirador-plugins.md#extra-reading)
-* [List of Custom Harvard Mirador Plugins](docs/custom-harvard-mirador-plugins.md)        
+* [List of Custom Harvard Mirador Plugins](docs/custom-harvard-mirador-plugins.md)  
+* [List of Community Mirador Plugins used by MPS Viewer](docs/community-mirador-plugins.md)        
 
 ## Local Development Environment Setup Instructions
 

--- a/docs/community-mirador-plugins.md
+++ b/docs/community-mirador-plugins.md
@@ -1,0 +1,7 @@
+# Community Mirador Plugins used by MPS Viewer
+
+This is a list of Community Mirador Plugins that is used in MPS Viewer.
+
+* [mirador-image-tools](https://github.com/ProjectMirador/mirador-image-tools) - A Mirador 3 plugin that adds image manipulation tools to the user interface.
+* [mirador-share-plugin](https://github.com/ProjectMirador/mirador-share-plugin) - A Mirador 3 plugin for adding share links, embedded iframes, drag-and-drop icon.
+* [mirador-dl-plugin](https://github.com/ProjectMirador/mirador-dl-plugin) - A Mirador 3 plugin that adds manifest-provided download links to the window options menu.


### PR DESCRIPTION
**Adding community mirador plugins to README.**
* * *

**JIRA Ticket**: [LTSVIEWER-215](https://jira.huit.harvard.edu/browse/LTSVIEWER-215)

# What does this Pull Request do?
This adds a new page to the README table of contents which lists the community plugins we are using in MPS Viewer.

# How should this be tested?

A description of what steps someone could take to:
* Pull in the latest code from the LTSVIEWER-215 branch
* Confirm that the new item in the Table of Contents works and makes sense.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff 