### PR TITLE
Include 50 characters of citation in <title> element

### DIFF
--- a/views/template.eta
+++ b/views/template.eta
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>MPS Viewer</title>
+    <title><%= it.title.slice(0,50) %> - MPS Viewer</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon">

--- a/views/template.eta
+++ b/views/template.eta
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title><%= it.title.slice(0,50) %> - MPS Viewer</title>
+    <title><%= it.title.slice(0,50) %> - Harvard Viewer</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon">

--- a/views/viewer.eta
+++ b/views/viewer.eta
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title><%= it.title %></title>
+    <title><%= it.title.slice(0,50) %> - Harvard Viewer</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="text/javascript">


### PR DESCRIPTION
**Include 50 characters of citation in <title> element**
* * *

**JIRA Ticket**: [LTSVIEWER-234](https://jira.huit.harvard.edu/browse/LTSVIEWER-234)

# What does this Pull Request do?
Adds the citation title into the tab; also truncates to the first 50 characters of the citation so that the tab text isn't too long

# How should this be tested?

A description of what steps someone could take to:
* Spin up Viewer from this branch
* From the homepage, you'll notice the tab title reads “Welcome to the MPS Viewer! - Mirador Viewer”
* If you click on an item with more than 50 characters, such as Chronique du monde, that item's tab title reads "Chronique du monde depuis la création, et des rois - MPS Viewer"
* If you click on an item with 50 characters or less, such as the baseball photograph (which is right at 50 characters), that item's tab title reads "Harvard University Baseball Team, photograph, 1892 - MPS Viewer"

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz