### PR TITLE
Updating mirador-pdiiif-plugin to 0.1.27.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
         "@harvard-lts/mirador-help-plugin": "^1.0.2",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.24",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.27",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -711,9 +711,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.24.tgz",
-      "integrity": "sha512-UOpHfl/o4BenOpNpI/wQyrm6VfcCshwyd5u0SMBkL0sXLWMBqyXC8opPVz0cRA9P4frhcbIiu+P2UhXa/kWwYg==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.27.tgz",
+      "integrity": "sha512-pyjF9Bc25LUtiIIOiqLdVHfd2+qT8ygpwxsaroe8k69D+GtLhq4sJlMj+Dj32zazOJcBD5ITcsyc6EHCcrRDEg==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
@@ -9532,9 +9532,9 @@
       "requires": {}
     },
     "@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.24.tgz",
-      "integrity": "sha512-UOpHfl/o4BenOpNpI/wQyrm6VfcCshwyd5u0SMBkL0sXLWMBqyXC8opPVz0cRA9P4frhcbIiu+P2UhXa/kWwYg==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.27.tgz",
+      "integrity": "sha512-pyjF9Bc25LUtiIIOiqLdVHfd2+qT8ygpwxsaroe8k69D+GtLhq4sJlMj+Dj32zazOJcBD5ITcsyc6EHCcrRDEg==",
       "requires": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
     "@harvard-lts/mirador-help-plugin": "^1.0.2",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.24",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.27",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**Updating mirador-pdiiif-plugin to 0.1.27.**
* * *

**JIRA Ticket**: [LTSVIEWER-259](https://jira.huit.harvard.edu/browse/LTSVIEWER-259)

# What does this Pull Request do?
This upgrades the Mirador PDIIIF Plugin to version 0.1.27. This removes the fallback to https://pdiiif.jbaiter.de/ for building coverpages. This way we can create PDFs without any coverpages.

# How should this be tested?

A description of what steps someone could take to:
* Change the endpoint variable in your `.env` to be empty: `PDIIIF_COVERPAGE_ENDPOINT=`
* Rebuild the mps-viewer container using `LTSVIEWER-259` branch
* Confirm that no cover page is created when saving PDFs for any object.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff 