### PR TITLE
Updating mirador-help-plugin to 1.0.0

### DIFF
--- a/docs/developing-mirador-plugins.md
+++ b/docs/developing-mirador-plugins.md
@@ -90,7 +90,7 @@ Publishing to NPM is handled by a Github Actions workflow. In order to use the w
 
 ### Publishing via Github
 
-Draft a new release in the Github UI and create a tag for the version number that you'd like to publish to NPM. Do this for the `main` branch (after the feature has been merged). When the action completes the version published to NPM will match the tag used when creating the release.  
+Draft a new release in the Github UI and create a tag for the version number that you'd like to publish to NPM (there should not be a "v" in the tag name). Do this for the `main` branch (after the feature has been merged). When the action completes the version published to NPM will match the tag used when creating the release.  
 
 In the unlikely event the action fails, you'll probably want to delete the release and the tag (in that order), debug the errors and then try again.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
-        "@harvard-lts/mirador-help-plugin": "^1.0.2",
+        "@harvard-lts/mirador-help-plugin": "^1.1.0",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
         "@harvard-lts/mirador-pdiiif-plugin": "^0.1.27",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
@@ -677,12 +677,13 @@
       }
     },
     "node_modules/@harvard-lts/mirador-help-plugin": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "mirador": "^3.3.0",
-        "react": "16.x",
-        "react-dom": "16.x"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.1.0.tgz",
+      "integrity": "sha512-oRjFaL6DbP2eu3HmaWuCyc1q28yLL+OqeJtb44KKsR5y1vYQKl7f/pOWvmqFX7runwUOaWgqPfiasChDd3H3gw==",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0"
       }
     },
     "node_modules/@harvard-lts/mirador-hide-nav-plugin": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
-    "@harvard-lts/mirador-help-plugin": "^1.0.2",
+    "@harvard-lts/mirador-help-plugin": "^1.1.0",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
     "@harvard-lts/mirador-pdiiif-plugin": "^0.1.27",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",


### PR DESCRIPTION
**Updating mirador-help-plugin to 1.0.0**
* * *

**JIRA Ticket**: [LTSVIEWER-244](https://jira.huit.harvard.edu/browse/LTSVIEWER-244)

* PR with the plugin work: https://github.com/harvard-lts/mirador-help-plugin/pull/10

# What does this Pull Request do?
Pulls in the newest version of mirador-help-plugin, v1.0.0.

These changes have already been built to npmjs as [@harvard-lts/mirador-help-plugin 1.0.0](https://www.npmjs.com/package/@harvard-lts/mirador-help-plugin).

# How should this be tested?

A description of what steps someone could take to:
* Spinup viewer from this branch
* Navigate to the help modal window
* Window should reflect the newest version of the help plugin, which only contains 2 links

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 