### PR TITLE
Update mirador-share-plugin version to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "mirador": "^3.3.0",
         "mirador-dl-plugin": "^0.13.0",
         "mirador-image-tools": "^0.11.0",
-        "mirador-share-plugin": "^0.11.0",
+        "mirador-share-plugin": "^0.12.0",
         "morgan": "^1.10.0",
         "passport": "^0.6.0",
         "passport-local": "^1.0.0",
@@ -6305,8 +6305,9 @@
       }
     },
     "node_modules/mirador-share-plugin": {
-      "version": "0.11.0",
-      "license": "Apache-2.0",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/mirador-share-plugin/-/mirador-share-plugin-0.12.0.tgz",
+      "integrity": "sha512-J17UWLLIfj1YpKI/7fnzs86YbmGEZgKhkPyE+ItecNQR6Wvhl0/pRdazzU8CHQgl4ondlnAyw6N8EWXlkEMsIA==",
       "peerDependencies": {
         "@material-ui/core": "^4.7.2",
         "@material-ui/icons": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "mirador": "^3.3.0",
     "mirador-dl-plugin": "^0.13.0",
     "mirador-image-tools": "^0.11.0",
-    "mirador-share-plugin": "^0.11.0",
+    "mirador-share-plugin": "^0.12.0",
     "morgan": "^1.10.0",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
**Update mirador-share-plugin version to 0.12.0**
* * *

**JIRA Tickets**: 
* [LTSVIEWER-242: Differentiate "Copy" labels in Share dialog](https://jira.huit.harvard.edu/browse/LTSVIEWER-242)
* [LTSVIEWER-243: Add descriptive label to form field in Share dialog](https://jira.huit.harvard.edu/browse/LTSVIEWER-243)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
   * PR with the plugin work: https://github.com/ProjectMirador/mirador-share-plugin/pull/47

# What does this Pull Request do?
Pulls in the newest version of mirador-share-plugin, v0.12.0.

These changes have already been built to npmjs as [@harvard-lts/mirador-share-plugin 0.12.0](https://www.npmjs.com/package/mirador-share-plugin).

# How should this be tested?
A description of what steps someone could take to:
* Spin up viewer from this branch
* Navigate to the share modal window
* Window should reflect the newest version of the share plugin;
   * Each "Copy" button should have an associated aria-label that read "Copy link" and "Copy code"
   * The "Copy & paste code" is now a label element

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz 