### PR TITLE
Updating the site design to the Beta Viewer mockups.

### DIFF
--- a/controllers/embed.ctrl.js
+++ b/controllers/embed.ctrl.js
@@ -3,14 +3,14 @@ const consoleLogger = require('../logger/logger.js').console;
 
 const embedCtrl = {};
 
-embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVersion = '3') => {
+embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVersion = '3', height = 700, width = 1200) => {
 
   let embedUrl = process.env.EMBED_BASE_URL;
 
   if (manifestType === 'legacy') {
-    embedUrl += `/api/legacy?recordIdentifier=${uniqueIdentifier}`
+    embedUrl += `/api/legacy?recordIdentifier=${uniqueIdentifier}&height=${height}&width=${width}`
   } else {
-    embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}`;
+    embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}`;
   }
 
   consoleLogger.info('embedUrl');

--- a/public/css/compiled/style.min.css
+++ b/public/css/compiled/style.min.css
@@ -28,7 +28,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 /* HEADER */
 .hl__header-child__title {
-    background-image: linear-gradient(-46deg, #52757e 0%, #335C67 100%);
+    background-image: linear-gradient(-46deg, #006ba9 0%,#1d4873 100%);
     color: white;
     flex: auto;
     font-family: 'Lora', Georgia, Times New Roman, serif;

--- a/public/css/compiled/style.min.css
+++ b/public/css/compiled/style.min.css
@@ -28,7 +28,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 /* HEADER */
 .hl__header-child__title {
-    background-image: linear-gradient(-46deg, #006ba9 0%,#1d4873 100%);
+    background-image: linear-gradient(-46deg,#0579b8 0%,#2a5280 100%);
     color: white;
     flex: auto;
     font-family: 'Lora', Georgia, Times New Roman, serif;
@@ -119,17 +119,43 @@ h1, h2, h3, h4, h5, h6 {
         text-align: left;
    }
 }
-/* time stamp */
-.hl__time-stamp {
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: #1e1e1e;
-}
+
+/* Additional spacing */
 .row {
     margin-bottom: 50px;
 }
-
 .hl__footer .row {
     margin-bottom: 0
+}
+
+/* MODAL */
+.modal-header h5 {
+    font-size: 22px;
+}
+.modal-header button.close {
+    border-radius: 50%;
+    padding: 0.5em;
+    width: 29px;
+    height: 29px;
+    display: inline-block;
+    background: #6c6c6c;
+    position: relative;
+    transition: all 0.4s ease;
+    opacity: 1;
+  }
+.modal-header button.close span {
+    color: transparent;
+    position: absolute;
+    top: -1px;
+    font-size: 36px;
+    right: 5px;
+    line-height: 29px;
+    font-weight: normal;
+}
+.modal-header button.close:hover,
+.modal-header button.close:focus {
+    background: #eb001b;
+}
+.modal-body {
+    font-family: 'Trueno', Arial, Helvetica, sans-serif;
 }

--- a/public/netlify.html
+++ b/public/netlify.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>MPS Viewer</title>
+    <title>Harvard Viewer</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon">
@@ -31,7 +31,7 @@
               <a href="#content" accesskey="S" onclick="$('#content').focus();" class="sr-only sr-only-focusable visually-hidden-focusable">Skip to Main Content</a>
             </div>
             <h1 class="hl__header-child__title ">
-              <a href="/" title="MPS Viewer"><span>MPS</span> Viewer</a>
+              <a href="/" title="Beta Viewer"><span>Beta</span> Viewer</a>
             </h1>
             <div class="hl__header-child__logo">
               <div class="hl__linked-image">
@@ -48,7 +48,7 @@
             <div class="row">
                 <div class="col-md-12">
                     <iframe id="miradorViewer"
-                        title="Mirador Viewer"
+                        title="Harvard Viewer"
                         width="1200px"
                         height="100%"
                         src=""

--- a/routes/index.js
+++ b/routes/index.js
@@ -29,18 +29,23 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     let title = '';
     let iiifManifest = '';
     let errorMsg = '';
+    let introMsg = 'Welcome to the Harvard Library Viewer\'s beta release. ';
+    let infoLink = {label: 'More Information.', url: '#'}
     // Unique identifier will be a urn (mps) or record identifier (legacy)
     const uniqueIdentifier = req.params.uniqueIdentifier;
     // Manifest type will be either 'mps' or 'legacy'
     const manifestType = req.params.manifestType || 'mps';
     // Manifest version will be 2 or 3
     const manifestVersion = req.query.manifestVersion || '3';
+    // Height and Width of Viewer
+    const height = '';
+    const width = '100%';
 
     consoleLogger.debug("/example/:manifestType/:uniqueIdentifier");
-    consoleLogger.debug(`uniqueIdentifier ${uniqueIdentifier} manifestType ${manifestType} manifestVersion ${manifestVersion}`);
+    consoleLogger.debug(`uniqueIdentifier ${uniqueIdentifier} manifestType ${manifestType} manifestVersion ${manifestVersion} height ${height} width ${width}`);
 
     try {
-      embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion);
+      embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion, height, width);
     } catch(e) {
       consoleLogger.error(e);
     }
@@ -66,6 +71,8 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
       title: title,
       viewerURL: viewerURL,
       iiifManifest: iiifManifest,
+      introMsg: introMsg,
+      infoLink: infoLink,
       error: errorMsg,
     });
 });

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,7 +18,7 @@ router.get("/", async (req, res) => {
   const mpsExamples = exampleItems.mpsExamples;
 
   res.render("index", {
-    title: "Welcome to the MPS Viewer!",
+    title: "",
     idsExamples: idsExamples,
     mpsExamples: mpsExamples
   });
@@ -29,8 +29,6 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     let title = '';
     let iiifManifest = '';
     let errorMsg = '';
-    let introMsg = 'Welcome to the Harvard Library Viewer\'s beta release. ';
-    let infoLink = {label: 'More Information.', url: '#'}
     // Unique identifier will be a urn (mps) or record identifier (legacy)
     const uniqueIdentifier = req.params.uniqueIdentifier;
     // Manifest type will be either 'mps' or 'legacy'
@@ -71,8 +69,6 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
       title: title,
       viewerURL: viewerURL,
       iiifManifest: iiifManifest,
-      introMsg: introMsg,
-      infoLink: infoLink,
       error: errorMsg,
     });
 });

--- a/views/example.eta
+++ b/views/example.eta
@@ -1,55 +1,12 @@
 <% layout('./template') %>
 
 <div id="main-container" class="container-fluid">
-    <div class="row m-0">
-        <div class="col-md-12">
-            <% if (it.introMsg) { %>
-            <p class="text-center">
-                <%~ it.introMsg %>
-                <% if (it.infoLink) { %>
-                    <a href="<%~ it.infoLink.url %>" data-bs-toggle="modal" data-bs-target="#infoModal"><%~ it.infoLink.label %></a>
-                <% } %>
-            </p>
-            <% } %>
-            <% if (it.error) { %>
-            <p>
-                <b>Error Message:</b> <%~ it.error %>
-            </p>
-            <% } %>
-        </div>
-    </div>
-    <% if (it.viewerURL) { %>
-    <div class="row">
-        <div class="col-md-12">
-            <%~ it.viewerURL %>
-        </div>
-    </div>
-    <% } %>
-</div>
-
-<!-- The Modal -->
-<div class="modal" id="infoModal">
-  <div class="modal-dialog modal-dialog-centered modal-lg">
-    <div class="modal-content">
-
-      <!-- Modal Header -->
-      <div class="modal-header">
-        <h5 class="text-secondary">BETA Viewer</h5>
-        <button type="button" class="btn btn-lrg p-1 text-dark border border-dark rounded-lg close" data-bs-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-
-      <!-- Modal body -->
-      <div class="modal-body">
-        This pre-release, open-beta site demonstrates new functionality and features currently in development. The beta will be updated as new features are ready and issues are fixed.  This is not the final version of the site, please see the <a href="https://ask.library.harvard.edu/faq/392399">known issues list</a>.
-      </div>
-
-      <!-- Modal footer -->
-      <div class="modal-footer">
-        <button type="button" class="btn btn-dark" data-bs-dismiss="modal">Close</button>
-      </div>
-
+  <%~ includeFile("./intro-message") %>
+  <% if (it.viewerURL) { %>
+  <div class="row">
+    <div class="col-md-12">
+      <%~ it.viewerURL %>
     </div>
   </div>
+  <% } %>
 </div>

--- a/views/example.eta
+++ b/views/example.eta
@@ -1,12 +1,14 @@
 <% layout('./template') %>
 
-<div id="main-container" class="container">
-    <div class="row">
+<div id="main-container" class="container-fluid">
+    <div class="row m-0">
         <div class="col-md-12">
-            <h2><%= it.title %></h2>
-            <% if (it.iiifManifest) { %>
-            <p>
-                <b>IIIF Manifest:</b> <a href="<%= it.iiifManifest %>" target="_blank"><%= it.iiifManifest %></a>
+            <% if (it.introMsg) { %>
+            <p class="text-center">
+                <%~ it.introMsg %>
+                <% if (it.infoLink) { %>
+                    <a href="<%~ it.infoLink.url %>" data-bs-toggle="modal" data-bs-target="#infoModal"><%~ it.infoLink.label %></a>
+                <% } %>
             </p>
             <% } %>
             <% if (it.error) { %>
@@ -23,4 +25,31 @@
         </div>
     </div>
     <% } %>
+</div>
+
+<!-- The Modal -->
+<div class="modal" id="infoModal">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+
+      <!-- Modal Header -->
+      <div class="modal-header">
+        <h5 class="text-secondary">BETA Viewer</h5>
+        <button type="button" class="btn btn-lrg p-1 text-dark border border-dark rounded-lg close" data-bs-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <!-- Modal body -->
+      <div class="modal-body">
+        This pre-release, open-beta site demonstrates new functionality and features currently in development. The beta will be updated as new features are ready and issues are fixed.  This is not the final version of the site, please see the <a href="https://ask.library.harvard.edu/faq/392399">known issues list</a>.
+      </div>
+
+      <!-- Modal footer -->
+      <div class="modal-footer">
+        <button type="button" class="btn btn-dark" data-bs-dismiss="modal">Close</button>
+      </div>
+
+    </div>
+  </div>
 </div>

--- a/views/header.eta
+++ b/views/header.eta
@@ -3,7 +3,7 @@
     <a href="#content" accesskey="S" onclick="$('#content').focus();" class="sr-only sr-only-focusable visually-hidden-focusable">Skip to Main Content</a>
   </div>
   <h1 class="hl__header-child__title ">
-    <a href="/" title="MPS Viewer"><span>MPS</span> Viewer</a>
+    <a href="/" title="Beta Viewer"><span>Beta</span> Viewer</a>
   </h1>
   <div class="hl__header-child__logo">
     <div class="hl__linked-image">

--- a/views/index.eta
+++ b/views/index.eta
@@ -1,12 +1,8 @@
 <% layout('./template') %>
 
 <div id="main-container" class="container">
-  <div class="row">
-    <div class="col-md-12">
-      <h2><%= it.title %></h2>
-    </div>
-  </div>
-  <div class="row">
+  <%~ includeFile("./intro-message") %>
+  <div class="row mt-4">
     <h3>IDS/PDS Examples (legacy)</h3>
     <div class="col-md-12">
       <div class="list-group">

--- a/views/intro-message.eta
+++ b/views/intro-message.eta
@@ -1,0 +1,34 @@
+<div class="row m-0">
+  <div class="col-md-12">
+    <p class="lead text-center">
+      Welcome to the Harvard Library Viewer's beta release. <a href="#" data-bs-toggle="modal" data-bs-target="#infoModal">More Information<span class="sr-only"> about the beta release</span>.</a>
+    </p>
+  </div>
+</div>
+
+<div class="modal fade" id="infoModal">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+
+      <!-- Modal Header -->
+      <div class="modal-header">
+        <h5 class="text-secondary">BETA Viewer</h5>
+        <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <!-- Modal body -->
+      <div class="modal-body text-secondary">
+        This pre-release, open-beta site demonstrates new Viewer functionality and features currently in development. The beta will be updated as new features are ready and issues are fixed. To learn more about what features are available now and how to use them, visit <a href="https://ask.library.harvard.edu/faq/392399">Using the new Viewer (Mirador)</a>.
+      </div>
+
+      <!-- Modal footer -->
+      <div class="modal-footer">
+        <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+
+    </div>
+  </div>
+</div>
+

--- a/views/template.eta
+++ b/views/template.eta
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title><%= it.title.slice(0,50) %> - Harvard Viewer</title>
+    <title>
+      <% if (it.title) { %>
+      <%= it.title.slice(0,50) %> -
+      <% } %>
+     Harvard Viewer
+    </title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon">

--- a/views/viewer.eta
+++ b/views/viewer.eta
@@ -1,7 +1,12 @@
 <!doctype html>
 <html>
   <head>
-    <title><%= it.title.slice(0,50) %> - Harvard Viewer</title>
+    <title>
+      <% if (it.title) { %>
+      <%= it.title.slice(0,50) %> -
+      <% } %>
+     Harvard Viewer
+    </title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="text/javascript">


### PR DESCRIPTION
**Updating the site design to the Beta Viewer mockups.**
* * *

**JIRA Ticket**: [LTSVIEWER-263](https://jira.huit.harvard.edu/browse/LTSVIEWER-263)

# What does this Pull Request do?
This updates the site design to look like the mockups in LTSVIEWER-263.

# How should this be tested?

A description of what steps someone could take to:
* **FIRST: Make sure you are running mps-embed locally using the `LTSVIEWER-263` branch there!** See this PR: https://github.com/harvard-lts/mps-embed/pull/34
* Rebuild the mps-viewer container using the `LTSVIEWER-263` branch
* Confirm that the site matches the mockups in LTSVIEWER-263. Things that are changed include:
  * The header is now blue instead of aqua.
  * The header now says `BETA Viewer` instead of `MPS Viewer`
  * The Mirador viewer now takes up 100% of the width of the page.
  * Above the Mirador viewer there welcoming you to the new Beta Viewer with a link to More Information
  * The Link to More Information opens a modal window with the text from the mockup.
  * The title and manifest url have been removed from above the Mirador Viewer.
  * 

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 