### PR TITLE
Adding new /manifest/ route to viewer for use with CURIOSity.

### DIFF
--- a/controllers/embed.ctrl.js
+++ b/controllers/embed.ctrl.js
@@ -8,10 +8,22 @@ embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVers
   let embedUrl = process.env.EMBED_BASE_URL;
 
   if (manifestType === 'legacy') {
-    embedUrl += `/api/legacy?recordIdentifier=${uniqueIdentifier}`
+    
   } else {
-    embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}`;
+    
   }
+
+  switch(manifestType) {
+    case 'legacy':
+      embedUrl += `/api/legacy?recordIdentifier=${uniqueIdentifier}`
+      break;
+    case 'mps':
+      embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}`;
+      break;
+    case 'manifest':
+      embedUrl += `/api/manifest?manifestId=${uniqueIdentifier}&manifestVersion=${manifestVersion}`;
+  }
+
 
   consoleLogger.info('embedUrl');
   consoleLogger.info(embedUrl);

--- a/routes/index.js
+++ b/routes/index.js
@@ -24,6 +24,47 @@ router.get("/", async (req, res) => {
   });
 });
 
+router.get("/example/manifest/", async (req, res) => {
+  let viewerURL = '';
+  let title = '';
+  let iiifManifest = '';
+  let errorMsg = '';
+  
+  const uniqueIdentifier = req.query.manifestId;
+  const manifestType = 'manifest';
+  const manifestVersion = '3';
+  
+  try {
+    embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion);
+  } catch(e) {
+    consoleLogger.error(e);
+  }
+
+  if (embed) {
+    if (embed.hasOwnProperty('error')) {
+      errorMsg = embed.error;
+    }
+    if (embed.data) {
+      if (embed.data.hasOwnProperty('html')) {
+        viewerURL = embed.data.html;
+      }
+      if (embed.data.hasOwnProperty('title')) { 
+        title = embed.data.title;
+      }
+      if (embed.data.hasOwnProperty('iiif_manifest')) {
+        iiifManifest = embed.data.iiif_manifest;
+      }
+    }
+  }
+
+  res.render("example", {
+    title: title,
+    viewerURL: viewerURL,
+    iiifManifest: iiifManifest,
+    error: errorMsg,
+  });
+}); 
+
 router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     let viewerURL = '';
     let title = '';


### PR DESCRIPTION
**Adding new /manifest/ route to viewer for use with CURIOSity.**
* * *

**JIRA Ticket**: [LTSVIEWER-263](https://jira.huit.harvard.edu/browse/LTSVIEWER-263)

# What does this Pull Request do?
This adds a new route to mps-viewer at /manifest/ that allows you to pass in any Manifest URL.

# How should this be tested?

A description of what steps someone could take to:
* FIRST rebuild the mps-embed container using the LTSVIEWER-263 branch
* Rebuild the mps-viewer container using the LTSVIEWER-264 branch
* Go to this url: https://localhost:23017/example/manifest/?manifestId=[manifestId] where [manifestId] can be the URL of any Manifest. For example: https://localhost:23017/example/manifest/?manifestId=https://iiif.lib.harvard.edu/manifests/drs:8282494
* You should see the item from the manifest displayed in the Mirador 3 viewer.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No 
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 