### PR TITLE
Upgrading mirador-pdiiif-plugin to 0.1.28.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
         "@harvard-lts/mirador-help-plugin": "^1.1.0",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.27",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.28",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -696,8 +696,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.27",
-      "license": "Apache-2.0",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.28.tgz",
+      "integrity": "sha512-ayrL1Zt5E6q2jKvdjJ1UY3d2vZYb1CMyARG/ki8KlbXIa47D8jXt3AoS0ysbBzURguhLapSjYlqpr5KSRtcV/A==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
     "@harvard-lts/mirador-help-plugin": "^1.1.0",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.27",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.28",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**Upgrading mirador-pdiiif-plugin to 0.1.28.**
* * *

**JIRA Ticket**: [LTSVIEWER-270](https://jira.huit.harvard.edu/browse/LTSVIEWER-270)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
Related PR for the mirador-pdiiif-plugin: https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/16

# What does this Pull Request do?
The PDF Download dialog box shows 0 bytes, because the plugin is expecting a number, but in mps-viewer it is actually getting an object. The object looks like this:
`Object { size: 502949479.7601479, corsSupported: true }`

# How should this be tested?

A description of what steps someone could take to:
* Build the mps-embed container off of the `main` branch
* Build the mps-viewer container off of the `LTSVIEWER-270` branch
* Confirm that the bytes are showing up properly for all examples in mps-viewer.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 