### PR TITLE
Adding prod argument to API call. Updating homepage template for examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,4 @@ dist/*
 .DS_Store
 
 # Configuration
-/config/*
-!/config/example-items-example.txt
+/config/example-items.json

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Docker Compose
 #### Create config file for environment variables
 - Make a copy of the example items example file `./config/example-items-example.txt`
 - Rename the file to `example-items.json`
-- Replace placeholder values as necessary
+- Replace placeholder values from one of the environment-specific json files included in the `/config/` folder.
 
 *Note: The config file .example-items.json is specifically excluded in .gitignore and .dockerignore, since the examples will differ from environment to environment.*
 

--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -1,0 +1,159 @@
+{
+	"idsExamples": [{
+			"version2": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
+			"version3": "",
+			"title": "Harvard University Baseball Team, photograph, 1892",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1507 x 1167px)"
+		},
+		{
+			"version2": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
+			"version3": "",
+			"title": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1663 x 1204px)"
+		},
+		{
+			"version2": "/example/legacy/W587091_URN-3:RAD.SCHL:11680642",
+			"version3": "",
+			"title": "To roast a chicken; show #217",
+			"owner": "Schlesinger Library on the History of Women in America",
+			"type": "single image",
+			"size": "x-small (563 x 568px)"
+		},
+		{
+			"version2": "/example/legacy/HUAM140429_URN-3:HUAM:INV012574P_DYNMC",
+			"version3": "",
+			"title": "Untitled Drumset",
+			"owner": "Harvard Art Museums",
+			"type": "single image",
+			"size": "small (1024 x 819px)"
+		},
+		{
+			"version2": "/example/legacy/990100671200203941",
+			"version3": "",
+			"title": "Hot Dog In The Manger",
+			"owner": "Harvard Art Museums",
+			"type": "page-turned object",
+			"size": "3 pages"
+		},
+		{
+			"version2": "/example/legacy/990095204340203941",
+			"version3": "",
+			"title": "Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass.",
+			"owner": "Houghton Library",
+			"type": "page-turned object",
+			"size": "41 pages"
+		},
+		{
+			"version2": "/example/legacy/990098789400203941",
+			"version3": "",
+			"title": "Heures de Nôtre Dame (use of Troyes and Sens) : manuscript, [ca. 1470]",
+			"owner": "Houghton Library",
+			"type": "page-turned object",
+			"size": "480 pages"
+		}
+	],
+	"mpsExamples": [{
+			"version2": "/example/mps/URN-3:HUL.OIS:101114808?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.OIS:101114808?manifestVersion=3",
+			"title": "Society for Basic Irreproducible Research, 010098243-METS.",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "123 pages 󠀠󠀠󠀠",
+			"environment": "DEV"
+		},
+		{
+			"version2": "/example/mps/URN-3:HUL.OIS:101114812?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.OIS:101114812?manifestVersion=3",
+			"title": "Society for Basic Irreproducible Research, 008971542_v001-METS.",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "751 pages 󠀠󠀠󠀠",
+			"environment": "DEV"
+		},
+		{
+			"version2": "/example/mps/URN-3:HUL.OIS:101114810?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.OIS:101114810?manifestVersion=3",
+			"title": "Society for Basic Irreproducible Research, 008106825_v001-METS.",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "258 pages 󠀠󠀠󠀠",
+			"environment": "DEV"
+		},
+		{
+			"version2": "/example/mps/URN-3:HUL.OIS:1254672?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.OIS:1254672?manifestVersion=3",
+			"title": "2000 node test pds object",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "transcripted, 2000 pages 󠀠󠀠󠀠",
+			"environment": "DEV"
+		},
+		{
+			"version2": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=3&prod=1",
+			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"owner": "Harvard Divinity School",
+			"type": "page-turned object",
+			"size": "4 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/URN-3:FHCL:42632611?manifestVersion=2&prod=1",
+			"version3": "/example/mps/URN-3:FHCL:42632611?manifestVersion=3&prod=1",
+			"title": "Fushun Xian zhi 37 juan. cc China] Tongzhi 11 [1872] 1872.",
+			"owner": "Harvard Yenching Library",
+			"type": "page-turned object",
+			"size": "116 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/URN-3:FHCL:100001249?manifestVersion=2&prod=1",
+			"version3": "/example/mps/URN-3:FHCL:100001249?manifestVersion=3&prod=1",
+			"title": "Tibetan Buddhist Resource Center.",
+			"owner": "Harvard Yenching Library",
+			"type": "page-turned object",
+			"size": "650 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
+			"owner": "Judaica Division, Widener Library",
+			"type": "single image",
+			"size": "small (1510 x 2052px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
+			"owner": "Kennedy School Library",
+			"type": "single image",
+			"size": "transcripted, medium (2568 x 3288px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
+			"owner": "Houghton Library",
+			"type": "single image",
+			"size": "large (4175 x 4816px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
+			"owner": "Dumbarton Oaks Research Library",
+			"type": "single image",
+			"size": "x-large (9698 x 7782px)",
+			"environment": "PROD"
+		}
+	]
+}

--- a/config/example-items-example.txt
+++ b/config/example-items-example.txt
@@ -1,22 +1,38 @@
 {
 	"idsExamples": [{
-			"href": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
-			"text": "Harvard University Baseball Team, photograph, 1892"
+			"version2": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
+			"version3": "",
+			"title": "Harvard University Baseball Team, photograph, 1892",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1507 x 1167px)"
 		},
 		{
-			"href": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
-			"text": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885"
+			"version2": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
+			"version3": "",
+			"title": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1663 x 1204px)"
 		},
 	],
 	"mpsExamples": [{
-			"href": "/example/mps/URN-3:DIV.LIB.USC:3200357?manifestVersion=2",
-			"text": "Harvard Divinity School Unitarian Service Committee",
-			"version": 2
+			"version2": "/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=3",
+			"title": "Mosquito brigades and how to organize them.",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "transcripted, 133 pages",
+			"environment": "QA"
 		},
 		{
-			"href": "/example/mps/URN-3:DIV.LIB.USC:3200357?manifestVersion=3",
-			"text": "Harvard Divinity School Unitarian Service Committee",
-			"version": 3
+			"version2": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=3&prod=1",
+			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"owner": "Harvard Divinity School",
+			"type": "page-turned object",
+			"size": "3 pages",
+			"environment": "PROD"
 		},
 	]
 }

--- a/config/example-items-prod.json
+++ b/config/example-items-prod.json
@@ -1,0 +1,123 @@
+{
+	"idsExamples": [{
+			"version2": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
+			"version3": "",
+			"title": "Harvard University Baseball Team, photograph, 1892",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1507 x 1167px)"
+		},
+		{
+			"version2": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
+			"version3": "",
+			"title": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1663 x 1204px)"
+		},
+		{
+			"version2": "/example/legacy/W587091_URN-3:RAD.SCHL:11680642",
+			"version3": "",
+			"title": "To roast a chicken; show #217",
+			"owner": "Schlesinger Library on the History of Women in America",
+			"type": "single image",
+			"size": "x-small (563 x 568px)"
+		},
+		{
+			"version2": "/example/legacy/HUAM140429_URN-3:HUAM:INV012574P_DYNMC",
+			"version3": "",
+			"title": "Untitled Drumset",
+			"owner": "Harvard Art Museums",
+			"type": "single image",
+			"size": "small (1024 x 819px)"
+		},
+		{
+			"version2": "/example/legacy/990100671200203941",
+			"version3": "",
+			"title": "Hot Dog In The Manger",
+			"owner": "Harvard Art Museums",
+			"type": "page-turned object",
+			"size": "3 pages"
+		},
+		{
+			"version2": "/example/legacy/990095204340203941",
+			"version3": "",
+			"title": "Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass.",
+			"owner": "Houghton Library",
+			"type": "page-turned object",
+			"size": "41 pages"
+		},
+		{
+			"version2": "/example/legacy/990098789400203941",
+			"version3": "",
+			"title": "Heures de Nôtre Dame (use of Troyes and Sens) : manuscript, [ca. 1470]",
+			"owner": "Houghton Library",
+			"type": "page-turned object",
+			"size": "480 pages"
+		}
+	],
+	"mpsExamples": [{
+			"version2": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=2",
+			"version3": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=3",
+			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"owner": "Harvard Divinity School",
+			"type": "page-turned object",
+			"size": "4 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/URN-3:FHCL:42632611?manifestVersion=2",
+			"version3": "/example/mps/URN-3:FHCL:42632611?manifestVersion=3",
+			"title": "Fushun Xian zhi 37 juan. cc China] Tongzhi 11 [1872] 1872.",
+			"owner": "Harvard Yenching Library",
+			"type": "page-turned object",
+			"size": "116 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/URN-3:FHCL:100001249?manifestVersion=2",
+			"version3": "/example/mps/URN-3:FHCL:100001249?manifestVersion=3",
+			"title": "Tibetan Buddhist Resource Center.",
+			"owner": "Harvard Yenching Library",
+			"type": "page-turned object",
+			"size": "650 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2",
+			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3",
+			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
+			"owner": "Judaica Division, Widener Library",
+			"type": "single image",
+			"size": "small (1510 x 2052px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2",
+			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3",
+			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
+			"owner": "Kennedy School Library",
+			"type": "single image",
+			"size": "transcripted, medium (2568 x 3288px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2",
+			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3",
+			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
+			"owner": "Houghton Library",
+			"type": "single image",
+			"size": "large (4175 x 4816px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2",
+			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3",
+			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
+			"owner": "Dumbarton Oaks Research Library",
+			"type": "single image",
+			"size": "x-large (9698 x 7782px)",
+			"environment": "PROD"
+		}
+	]
+}

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -1,0 +1,159 @@
+{
+	"idsExamples": [{
+			"version2": "/example/legacy/W401849_URN-3:HUL.ARCH:2009749",
+			"version3": "",
+			"title": "Harvard University Baseball Team, photograph, 1892",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1507 x 1167px)"
+		},
+		{
+			"version2": "/example/legacy/W401827_URN-3:HUL.ARCH:2009747",
+			"version3": "",
+			"title": "Harvard-Yale Baseball Game. Holmes Field, photograph, 1885",
+			"owner": "Harvard University Archives",
+			"type": "single image",
+			"size": "small (1663 x 1204px)"
+		},
+		{
+			"version2": "/example/legacy/W587091_URN-3:RAD.SCHL:11680642",
+			"version3": "",
+			"title": "To roast a chicken; show #217",
+			"owner": "Schlesinger Library on the History of Women in America",
+			"type": "single image",
+			"size": "x-small (563 x 568px)"
+		},
+		{
+			"version2": "/example/legacy/HUAM140429_URN-3:HUAM:INV012574P_DYNMC",
+			"version3": "",
+			"title": "Untitled Drumset",
+			"owner": "Harvard Art Museums",
+			"type": "single image",
+			"size": "small (1024 x 819px)"
+		},
+		{
+			"version2": "/example/legacy/990100671200203941",
+			"version3": "",
+			"title": "Hot Dog In The Manger",
+			"owner": "Harvard Art Museums",
+			"type": "page-turned object",
+			"size": "3 pages"
+		},
+		{
+			"version2": "/example/legacy/990095204340203941",
+			"version3": "",
+			"title": "Chronique du monde depuis la création, et des rois de France et d'Angleterre, jusqu'à l'an 1461: manuscript, [ca. 1461]. MS Typ 41. Houghton Library, Harvard University, Cambridge, Mass.",
+			"owner": "Houghton Library",
+			"type": "page-turned object",
+			"size": "41 pages"
+		},
+		{
+			"version2": "/example/legacy/990098789400203941",
+			"version3": "",
+			"title": "Heures de Nôtre Dame (use of Troyes and Sens) : manuscript, [ca. 1470]",
+			"owner": "Houghton Library",
+			"type": "page-turned object",
+			"size": "480 pages"
+		}
+	],
+	"mpsExamples": [{
+			"version2": "/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=3",
+			"title": "Mosquito brigades and how to organize them.",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "transcripted, 133 pages",
+			"environment": "QA"
+		},
+		{
+			"version2": "/example/mps/URN-3:HUL.OIS:100102314?manifestVersion=2",
+			"version3": "/example/mps/URN-3:HUL.OIS:100102314?manifestVersion=3",
+			"title": "Da Qing jin shen quan shu (Tongzhi jiu nian geng wu xia ji) cc Jingdu Rong lu tang Tongzhi 9 [1870].",
+			"owner": "Test item (no owner)",
+			"type": "page-turned object",
+			"size": "partially-transcripted, 420 pages",
+			"environment": "QA"
+		},
+		{
+			"version2": "/example/mps/URN-3:GSE.LIBR:100041477?manifestVersion=2",
+			"version3": "/example/mps/URN-3:GSE.LIBR:100041477?manifestVersion=3",
+			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 37. No. 3. May 1967. ",
+			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
+			"type": "page-turned object",
+			"size": "transcripted, 53 pages",
+			"environment": "QA"
+		},
+		{
+			"version2": "/example/mps/URN-3:GSE.LIBR:100037458?manifestVersion=2",
+			"version3": "/example/mps/URN-3:GSE.LIBR:100037458?manifestVersion=3",
+			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 23. No. 2. Mar. 1952.",
+			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
+			"type": "page-turned object",
+			"size": "transcripted, 25 pages",
+			"environment": "QA"
+		},
+		{
+			"version2": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:DIV.LIB:42551491?manifestVersion=3&prod=1",
+			"title": "Unitarian Service Committee. Case Files, 1938-1951.",
+			"owner": "Harvard Divinity School",
+			"type": "page-turned object",
+			"size": "4 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/URN-3:FHCL:42632611?manifestVersion=2&prod=1",
+			"version3": "/example/mps/URN-3:FHCL:42632611?manifestVersion=3&prod=1",
+			"title": "Fushun Xian zhi 37 juan. cc China] Tongzhi 11 [1872] 1872.",
+			"owner": "Harvard Yenching Library",
+			"type": "page-turned object",
+			"size": "116 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/URN-3:FHCL:100001249?manifestVersion=2&prod=1",
+			"version3": "/example/mps/URN-3:FHCL:100001249?manifestVersion=3&prod=1",
+			"title": "Tibetan Buddhist Resource Center.",
+			"owner": "Harvard Yenching Library",
+			"type": "page-turned object",
+			"size": "650 pages",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
+			"owner": "Judaica Division, Widener Library",
+			"type": "single image",
+			"size": "small (1510 x 2052px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
+			"owner": "Kennedy School Library",
+			"type": "single image",
+			"size": "transcripted, medium (2568 x 3288px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
+			"owner": "Houghton Library",
+			"type": "single image",
+			"size": "large (4175 x 4816px)",
+			"environment": "PROD"
+		},
+		{
+			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
+			"owner": "Dumbarton Oaks Research Library",
+			"type": "single image",
+			"size": "x-large (9698 x 7782px)",
+			"environment": "PROD"
+		}
+	]
+}

--- a/controllers/embed.ctrl.js
+++ b/controllers/embed.ctrl.js
@@ -3,7 +3,7 @@ const consoleLogger = require('../logger/logger.js').console;
 
 const embedCtrl = {};
 
-embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVersion = '3', height = 700, width = 1200) => {
+embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVersion = '3', height = 700, width = 1200, productionOverride = '') => {
 
   let embedUrl = process.env.EMBED_BASE_URL;
 
@@ -12,7 +12,7 @@ embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVers
       embedUrl += `/api/legacy?recordIdentifier=${uniqueIdentifier}&height=${height}&width=${width}`
       break;
     case 'mps':
-      embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}`;
+      embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}&prod=${productionOverride}`;
       break;
     case 'manifest':
       embedUrl += `/api/manifest?manifestId=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}`;

--- a/public/css/compiled/style.min.css
+++ b/public/css/compiled/style.min.css
@@ -159,3 +159,16 @@ h1, h2, h3, h4, h5, h6 {
 .modal-body {
     font-family: 'Trueno', Arial, Helvetica, sans-serif;
 }
+
+.list-group-item a {
+    font-family: 'Lora', Georgia, Times New Roman, serif;
+    
+}
+
+.list-group a {
+    border-bottom: none;
+}
+
+.list-group a:hover {
+    border-bottom: 3px solid #ADD3E6;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -78,15 +78,17 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     const manifestType = req.params.manifestType || 'mps';
     // Manifest version will be 2 or 3
     const manifestVersion = req.query.manifestVersion || '3';
+    // Used to override to use Production MPS to get the Manifest
+    const productionOverride = req.query.prod || '';    
     // Height and Width of Viewer
     const height = '';
     const width = '100%';
 
     consoleLogger.debug("/example/:manifestType/:uniqueIdentifier");
-    consoleLogger.debug(`uniqueIdentifier ${uniqueIdentifier} manifestType ${manifestType} manifestVersion ${manifestVersion} height ${height} width ${width}`);
+    consoleLogger.debug(`uniqueIdentifier ${uniqueIdentifier} manifestType ${manifestType} manifestVersion ${manifestVersion} height ${height} width ${width} productionOverride ${productionOverride}`);
 
     try {
-      embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion, height, width);
+      embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion, height, width, productionOverride);
     } catch(e) {
       consoleLogger.error(e);
     }

--- a/views/index.eta
+++ b/views/index.eta
@@ -1,25 +1,56 @@
 <% layout('./template') %>
 
+<% var badgeClasses = "" %>
+
 <div id="main-container" class="container">
   <%~ includeFile("./intro-message") %>
-  <div class="row mt-4">
-    <h3>IDS/PDS Examples (legacy)</h3>
-    <div class="col-md-12">
-      <div class="list-group">
-      <% it.idsExamples.forEach(function(idsExample){ %>
-        <a href="<%= idsExample.href %>" class="list-group-item list-group-item-action"><%= idsExample.text %></a>
-      <% }) %>
-      </div>
-    </div>
-  </div>
   <div class="row">
     <h3>MPS Examples</h3>
     <div class="col-md-12">
       <div class="list-group">
         <% it.mpsExamples.forEach(function(mpsExample){ %>
-          <a href="<%= mpsExample.href %>" class="list-group-item list-group-item-action"><%= mpsExample.text %> - version <%= mpsExample.version %></a> 
+          <% if (mpsExample.environment == "PROD") { 
+            badgeClasses = "bg-success text-white"
+          } else {
+            badgeClasses = "bg-warning text-dark"
+          } %>
+          <div class="list-group-item list-group-item-action">
+          <p class="b-0 m-0"><strong><%= mpsExample.title %></strong><br />
+            <%= mpsExample.owner %>, <%= mpsExample.type %>, <%= mpsExample.size %> <span class="badge rounded-pill <%= badgeClasses %>"><%= mpsExample.environment %></span>
+          </p>
+          <ul class="b-0 m-0">
+            <% if (mpsExample.version2) { %>
+              <li><a href="<%= mpsExample.version2 %>" class="font-weight-light">Version 2</a></li>
+            <% } %>
+            <% if (mpsExample.version3) { %>
+              <li><a href="<%= mpsExample.version3 %>" class="font-weight-light">Version 3</a></li>
+            <% } %>
+          </ul>
+        </div>
         <% }) %>
       </div>
     </div>
   </div>
+  <div class="row mt-4">
+    <h3>IDS/PDS Examples (legacy)</h3>
+    <div class="col-md-12">
+      <div class="list-group">
+      <% it.idsExamples.forEach(function(idsExample){ %>
+        <div class="list-group-item list-group-item-action">
+          <p class="b-0 m-0"><strong><%= idsExample.title %></strong><br />
+            <%= idsExample.owner %>, <%= idsExample.type %>, <%= idsExample.size %>
+          </p>
+          <ul class="b-0 m-0">
+            <% if (idsExample.version2) { %>
+              <li><a href="<%= idsExample.version2 %>" class="font-weight-light">Version 2</a></li>
+            <% } %>
+            <% if (idsExample.version3) { %>
+              <li><a href="<%= idsExample.version3 %>" class="font-weight-light">Version 3</a></li>
+            <% } %>
+          </ul>
+        </div>
+      <% }) %>
+      </div>
+    </div>
+  </div>  
 </div>


### PR DESCRIPTION
**Adding prod argument to API call. Updating homepage template for examples.**
* * *

**JIRA Ticket**: [LTSVIEWER-271](https://jira.huit.harvard.edu/browse/LTSVIEWER-271)

# What does this Pull Request do?
This adds a prod argument to API calls. This allows the homepages to mix both dev/qa examples and production examples. 

# How should this be tested?

A description of what steps someone could take to:

1. Copy the contents of `example-items-dev.json` into your `example-items.json` file.
2. Rebuild the mps-viewer container using the `LTSVIEWER-271` branch
3. Go to the homepage and confirm you see Dev and Production items under the MPS Examples heading, along with new information for each item including owner, object type, size and environment. 
4. Click on each item and confirm the json response shows up properly.
5. Repeat steps 2-4 using the QA and Production example.json files in the config folder.
6. **Do not merge this PR** until the related PR for mps-embed is also approved and ready to merge (https://github.com/harvard-lts/mps-embed/pull/37). Also please merge the files when Phil is available so he can also build the PR in MPS-VIEWER-IF (https://github.huit.harvard.edu/LTS/MPS-VIEWER-IF/pull/14) simultaneously.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 