### PR TITLE
Adding new nrs route and updating examples.

### DIFF
--- a/config/example-items-dev.json
+++ b/config/example-items-dev.json
@@ -59,6 +59,7 @@
 	"mpsExamples": [{
 			"version2": "/example/mps/URN-3:HUL.OIS:101114808?manifestVersion=2",
 			"version3": "/example/mps/URN-3:HUL.OIS:101114808?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:HUL.OIS:101114808",
 			"title": "Society for Basic Irreproducible Research, 010098243-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -68,6 +69,7 @@
 		{
 			"version2": "/example/mps/URN-3:HUL.OIS:101114812?manifestVersion=2",
 			"version3": "/example/mps/URN-3:HUL.OIS:101114812?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:HUL.OIS:101114812",
 			"title": "Society for Basic Irreproducible Research, 008971542_v001-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -77,6 +79,7 @@
 		{
 			"version2": "/example/mps/URN-3:HUL.OIS:101114810?manifestVersion=2",
 			"version3": "/example/mps/URN-3:HUL.OIS:101114810?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:HUL.OIS:101114810",
 			"title": "Society for Basic Irreproducible Research, 008106825_v001-METS.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -86,6 +89,7 @@
 		{
 			"version2": "/example/mps/URN-3:HUL.OIS:1254672?manifestVersion=2",
 			"version3": "/example/mps/URN-3:HUL.OIS:1254672?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:HUL.OIS:1254672",
 			"title": "2000 node test pds object",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -95,6 +99,7 @@
 		{
 			"version2": "/example/mps/URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:DIV.LIB:29999858?prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
@@ -104,6 +109,7 @@
 		{
 			"version2": "/example/mps/URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:HLS.LIBR:102621314?prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
@@ -113,6 +119,7 @@
 		{
 			"version2": "/example/mps/URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:GSE.LIBR:42470991?prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
 			"type": "page-turned object",
@@ -122,6 +129,7 @@
 		{
 			"version2": "/example/mps/URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:RAD.SCHL:101557499?prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
 			"type": "page-turned object",
@@ -131,6 +139,7 @@
 		{
 			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:FHCL.JUD:40308070?prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
 			"type": "single image",
@@ -140,6 +149,7 @@
 		{
 			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:KSG.LIBR:40505153?prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
 			"type": "single image",
@@ -149,6 +159,7 @@
 		{
 			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:FHCL.HOUGH:41301981?prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
 			"type": "single image",
@@ -158,6 +169,7 @@
 		{
 			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:DOAK.RESLIB:40977022?prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",
 			"type": "single image",

--- a/config/example-items-prod.json
+++ b/config/example-items-prod.json
@@ -59,6 +59,7 @@
 	"mpsExamples": [{
 			"version2": "/example/mps/URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:DIV.LIB:29999858?prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
@@ -68,6 +69,7 @@
 		{
 			"version2": "/example/mps/URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:HLS.LIBR:102621314?prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
@@ -77,6 +79,7 @@
 		{
 			"version2": "/example/mps/URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:GSE.LIBR:42470991?prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
 			"type": "page-turned object",
@@ -86,6 +89,7 @@
 		{
 			"version2": "/example/mps/URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:RAD.SCHL:101557499?prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
 			"type": "page-turned object",
@@ -93,8 +97,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2",
-			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3",
+			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:FHCL.JUD:40308070?prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
 			"type": "single image",
@@ -102,8 +107,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2",
-			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3",
+			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:KSG.LIBR:40505153?prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
 			"type": "single image",
@@ -111,8 +117,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2",
-			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3",
+			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:FHCL.HOUGH:41301981?prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
 			"type": "single image",
@@ -120,8 +127,9 @@
 			"environment": "PROD"
 		},
 		{
-			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2",
-			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3",
+			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
+			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:DOAK.RESLIB:40977022?prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",
 			"type": "single image",

--- a/config/example-items-qa.json
+++ b/config/example-items-qa.json
@@ -59,6 +59,7 @@
 	"mpsExamples": [{
 			"version2": "/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=2",
 			"version3": "/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:HUL.GUEST:409464",
 			"title": "Mosquito brigades and how to organize them.",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -68,6 +69,7 @@
 		{
 			"version2": "/example/mps/URN-3:HUL.OIS:100102314?manifestVersion=2",
 			"version3": "/example/mps/URN-3:HUL.OIS:100102314?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:HUL.OIS:100102314",
 			"title": "Da Qing jin shen quan shu (Tongzhi jiu nian geng wu xia ji) cc Jingdu Rong lu tang Tongzhi 9 [1870].",
 			"owner": "Test item (no owner)",
 			"type": "page-turned object",
@@ -77,6 +79,7 @@
 		{
 			"version2": "/example/mps/URN-3:GSE.LIBR:100041477?manifestVersion=2",
 			"version3": "/example/mps/URN-3:GSE.LIBR:100041477?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:GSE.LIBR:100041477",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 37. No. 3. May 1967. ",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
 			"type": "page-turned object",
@@ -86,6 +89,7 @@
 		{
 			"version2": "/example/mps/URN-3:GSE.LIBR:100037458?manifestVersion=2",
 			"version3": "/example/mps/URN-3:GSE.LIBR:100037458?manifestVersion=3",
+			"nrs": "/example/nrs/URN-3:GSE.LIBR:100037458",
 			"title": "North Carolina teachers record. Raleigh, N.C. North Carolina Teachers Association. Volume 23. No. 2. Mar. 1952.",
 			"owner": "Wilson Library, University of North Carolina Chapel Hill, Black Teacher Archive",
 			"type": "page-turned object",
@@ -95,6 +99,7 @@
 		{
 			"version2": "/example/mps/URN-3:DIV.LIB:29999858?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:DIV.LIB:29999858?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:DIV.LIB:29999858?prod=1",
 			"title": "Foote, Henry Wilder, 1875-1964. Papers of Professor Henry Wilder Foote and Family, 1714-1959.",
 			"owner": "Harvard Divinity School",
 			"type": "page-turned object",
@@ -104,6 +109,7 @@
 		{
 			"version2": "/example/mps/URN-3:HLS.LIBR:102621314?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:HLS.LIBR:102621314?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:HLS.LIBR:102621314?prod=1",
 			"title": "Cecil F. Poole Papers, 1939-1997. Speeches.",
 			"owner": "Harvard Law School Library, Historical & Special Collections",
 			"type": "page-turned object",
@@ -113,6 +119,7 @@
 		{
 			"version2": "/example/mps/URN-3:GSE.LIBR:42470991?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:GSE.LIBR:42470991?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:GSE.LIBR:42470991?prod=1",
 			"title": "Richards, I. A. (Ivor Armstrong) 1893-1979. Spansk gennem billeder. no 1975.",
 			"owner": "Gutman Library",
 			"type": "page-turned object",
@@ -122,6 +129,7 @@
 		{
 			"version2": "/example/mps/URN-3:RAD.SCHL:101557499?manifestVersion=2&prod=1",
 			"version3": "/example/mps/URN-3:RAD.SCHL:101557499?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:RAD.SCHL:101557499?prod=1",
 			"title": "National Organization for Women Newsletter Collection. New York. Nassau County chapter. Nassau NOW Times. Pr-1.",
 			"owner": "Radcliffe Institute",
 			"type": "page-turned object",
@@ -131,6 +139,7 @@
 		{
 			"version2": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:FHCL.JUD:40308070?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:FHCL.JUD:40308070?prod=1",
 			"title": "Agor, Ya'akov, Israeli. Muze'on ha-ketav in Acre, Israel. 1960 - 1970.",
 			"owner": "Judaica Division, Widener Library",
 			"type": "single image",
@@ -140,6 +149,7 @@
 		{
 			"version2": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:KSG.LIBR:40505153?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:KSG.LIBR:40505153?prod=1",
 			"title": "Krivokhizha, V. I. (VasiliÄ­ Iosifovich), 1947- Russia's national security policy, conceptions and realities.",
 			"owner": "Kennedy School Library",
 			"type": "single image",
@@ -149,6 +159,7 @@
 		{
 			"version2": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:FHCL.HOUGH:41301981?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:FHCL.HOUGH:41301981?prod=1",
 			"title": "Thomas Prince journal, 1710-1751. MS Am 3039.",
 			"owner": "Houghton Library",
 			"type": "single image",
@@ -158,6 +169,7 @@
 		{
 			"version2": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=2&prod=1",
 			"version3": "/example/mps/urn-3:DOAK.RESLIB:40977022?manifestVersion=3&prod=1",
+			"nrs": "/example/nrs/URN-3:DOAK.RESLIB:40977022?prod=1",
 			"title": "Nativity. Church of Panagia tou Arakos, nave, west bay, south side, vault, wall paintings, Lagoudera, Cyprus, 1192.",
 			"owner": "Dumbarton Oaks Research Library",
 			"type": "single image",

--- a/controllers/embed.ctrl.js
+++ b/controllers/embed.ctrl.js
@@ -14,6 +14,9 @@ embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVers
     case 'mps':
       embedUrl += `/api/mps?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}&prod=${productionOverride}`;
       break;
+    case 'nrs':
+      embedUrl += `/api/nrs?urn=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}&prod=${productionOverride}`;
+      break;      
     case 'manifest':
       embedUrl += `/api/manifest?manifestId=${uniqueIdentifier}&manifestVersion=${manifestVersion}&height=${height}&width=${width}`;
   }

--- a/views/index.eta
+++ b/views/index.eta
@@ -25,6 +25,9 @@
             <% if (mpsExample.version3) { %>
               <li><a href="<%= mpsExample.version3 %>" class="font-weight-light">Version 3</a></li>
             <% } %>
+            <% if (mpsExample.nrs) { %>
+              <li><a href="<%= mpsExample.nrs %>" class="font-weight-light">NRS</a></li>
+            <% } %>            
           </ul>
         </div>
         <% }) %>
@@ -46,6 +49,9 @@
             <% } %>
             <% if (idsExample.version3) { %>
               <li><a href="<%= idsExample.version3 %>" class="font-weight-light">Version 3</a></li>
+            <% } %>
+            <% if (idsExample.nrs) { %>
+              <li><a href="<%= idsExample.nrs %>" class="font-weight-light">NRS</a></li>
             <% } %>
           </ul>
         </div>


### PR DESCRIPTION
**Adding new nrs route and updating examples.**
* * *

**JIRA Ticket**: [LTSVIEWER-261](https://jira.huit.harvard.edu/browse/LTSVIEWER-261)

# What does this Pull Request do?
This adds a new route at /example/nrs/. It allows you to pass in a URN and then it uses NRS to get the IIIF Manifest and Viewer. At this time NRS will always return a Mirador 2 Viewer.

# How should this be tested?

A description of what steps someone could take to:
* Bring up mps-embed on the LTSVIEWER-261 following the instructions in this PR: https://github.com/harvard-lts/mps-embed/pull/40
* Update your `example-items.json` file using the desired environment. The environment needs to match what is running in mps-embed.
* Bring up mps-viewer using the `LTSVIEWER-261` branch.
* Go to the homepage and confirm that the new NRS links for each item bring up a working Mirador2 Viewer with the item inside of it.
* Repeat the steps for other environments.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@f8f8ff @enriquediaz 