### PR TITLE
Upgrade mirador-help-plugin to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
         "@harvard-lts/mirador-harvard-custom-plugin": "^1.0.0",
-        "@harvard-lts/mirador-help-plugin": "^1.1.0",
+        "@harvard-lts/mirador-help-plugin": "^1.2.0",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
         "@harvard-lts/mirador-pdiiif-plugin": "^0.1.28",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
@@ -690,9 +690,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-help-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.1.0.tgz",
-      "integrity": "sha512-oRjFaL6DbP2eu3HmaWuCyc1q28yLL+OqeJtb44KKsR5y1vYQKl7f/pOWvmqFX7runwUOaWgqPfiasChDd3H3gw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-help-plugin/-/mirador-help-plugin-1.2.0.tgz",
+      "integrity": "sha512-SUvUuTIRgPIq2TiemALirNMDVJmNehuYpcKIGrLG4GeRCWE04m+dFPquxh19OUesvoDSDO9801cynBUAoAAmSQ==",
       "dependencies": {
         "prop-types": "^15.8.1",
         "react": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@harvard-lts/mirador-analytics-plugin": "^0.3.0",
     "@harvard-lts/mirador-harvard-custom-plugin": "^1.0.0",
-    "@harvard-lts/mirador-help-plugin": "^1.1.0",
+    "@harvard-lts/mirador-help-plugin": "^1.2.0",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
     "@harvard-lts/mirador-pdiiif-plugin": "^0.1.28",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",


### PR DESCRIPTION
**Upgrade mirador-help-plugin to 1.2.0**
* * *

**JIRA Ticket**: [LTSVIEWER-92](https://jira.huit.harvard.edu/browse/LTSVIEWER-92)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
   * PR with the plugin work: https://github.com/harvard-lts/mirador-help-plugin/pull/12

# What does this Pull Request do?
Renames the self-help documentation link and updates it to point to the LibAnswers knowledge base article

These changes have already been built to npmjs as [@harvard-lts/mirador-help-plugin 1.2.0](https://www.npmjs.com/package/@harvard-lts/mirador-help-plugin).

# How should this be tested?
* Spin up viewer from this branch
* Open the "Help" modal window
* Confirm that the first list item reads "Using the Viewer" and points to https://ask.library.harvard.edu/faq/392399

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 