### PR TITLE
Upgrade mirador-pdiiif-plugin to 0.1.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@harvard-lts/mirador-harvard-custom-plugin": "^1.0.0",
         "@harvard-lts/mirador-help-plugin": "^1.2.0",
         "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.28",
+        "@harvard-lts/mirador-pdiiif-plugin": "^0.1.29",
         "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
         "axios": "^1.3.5",
         "body-parser": "^1.20.2",
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@harvard-lts/mirador-pdiiif-plugin": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.28.tgz",
-      "integrity": "sha512-ayrL1Zt5E6q2jKvdjJ1UY3d2vZYb1CMyARG/ki8KlbXIa47D8jXt3AoS0ysbBzURguhLapSjYlqpr5KSRtcV/A==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@harvard-lts/mirador-pdiiif-plugin/-/mirador-pdiiif-plugin-0.1.29.tgz",
+      "integrity": "sha512-t/JBSlFeKPMxUs1M9w+FEgln0L+1COcXbdVeY6nr89lO2EDCpxG+hh7qNK8whSkjC525ijP/O0OKFMNygLDAlg==",
       "dependencies": {
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@harvard-lts/mirador-harvard-custom-plugin": "^1.0.0",
     "@harvard-lts/mirador-help-plugin": "^1.2.0",
     "@harvard-lts/mirador-hide-nav-plugin": "^1.0.1",
-    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.28",
+    "@harvard-lts/mirador-pdiiif-plugin": "^0.1.29",
     "@harvard-lts/mirador-url-sync-plugin": "^0.1.2",
     "axios": "^1.3.5",
     "body-parser": "^1.20.2",


### PR DESCRIPTION
**Upgrade mirador-pdiiif-plugin to 0.1.29**
* * *

**JIRA Ticket**: [LTSVIEWER-227](https://jira.huit.harvard.edu/browse/LTSVIEWER-227)

* Other Relevant Links
   * PR with the plugin work: https://github.com/harvard-lts/mirador-pdiiif-plugin/pull/17

# What does this Pull Request do?
Disables page range input field when download is complete.

These changes have already been built to npmjs as [@harvard-lts/mirador-pdiiif-plugin 0.1.29](https://www.npmjs.com/package/@harvard-lts/mirador-pdiiif-plugin).

# How should this be tested?

- Spin up viewer from this branch
- Open the "Download PDF" modal window (a dropdown option under the three dots in the top right of viewer)
- Begin a download and confirm that the page range input field is disabled both during the download and after the download has completed
- Close the modal window and reopen it
- Confirm that the page range input field is enabled again

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 