### PR TITLE
Adding height and width request variables.

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -83,8 +83,8 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     // Used to override to use Production MPS to get the Manifest
     const productionOverride = req.query.prod || '';    
     // Height and Width of Viewer
-    const height = '';
-    const width = '100%';
+    const height = req.query.height || '';
+    const width = req.query.width || '100%';
 
     consoleLogger.debug("/example/:manifestType/:uniqueIdentifier");
     consoleLogger.debug(`uniqueIdentifier ${uniqueIdentifier} manifestType ${manifestType} manifestVersion ${manifestVersion} height ${height} width ${width} productionOverride ${productionOverride}`);


### PR DESCRIPTION
**Adding height and width request variables.**
* * *

**JIRA Ticket**: [LTSVIEWER-284](https://at-harvard.atlassian.net/browse/)

# What does this Pull Request do?
This adds the ability to customize the height and width of the viewer that is displayed on the example pages using request variables. 

# How should this be tested?

A description of what steps someone could take to:
* Spin up `mps-embed` off of the `main` branch
* Spin up `mps-viewer` off of the `LTSVIEWER-284` branch
* Go to any example page and the Viewer should display full screen (the same as before)
* Adding `height` and `width` to the end of the url will adjust the size of the viewer. For example: https://localhost:23017/example/mps/URN-3:HUL.GUEST:409464?manifestVersion=3&height=700&width=1200
* I believe `height=700` and `width=1200` was the previous default size for Viewer so we should be able to see the resize issue using those settings, but any dimensions can be passed in.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No 
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 