### PR TITLE
Adding style to account for embed always returning 100% height and 100% width.

### DIFF
--- a/controllers/embed.ctrl.js
+++ b/controllers/embed.ctrl.js
@@ -3,7 +3,7 @@ const consoleLogger = require('../logger/logger.js').console;
 
 const embedCtrl = {};
 
-embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVersion = '3', height = 700, width = 1200, productionOverride = '') => {
+embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVersion = '3', height = '100%', width = '100%', productionOverride = '') => {
 
   let embedUrl = process.env.EMBED_BASE_URL;
 

--- a/public/css/compiled/style.min.css
+++ b/public/css/compiled/style.min.css
@@ -172,3 +172,8 @@ h1, h2, h3, h4, h5, h6 {
 .list-group a:hover {
     border-bottom: 3px solid #ADD3E6;
 }
+
+.viewer-wrapper {
+    width:100%;
+    min-height: 700px;
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -35,7 +35,7 @@ router.get("/example/manifest/", async (req, res) => {
   const manifestType = 'manifest';
   const manifestVersion = '3';
   // Height and Width of Viewer
-  const height = '';
+  const height = '100%';
   const width = '100%';
   try {
     embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion, height, width);
@@ -83,8 +83,8 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     // Used to override to use Production MPS to get the Manifest
     const productionOverride = req.query.prod || '';    
     // Height and Width of Viewer
-    const height = req.query.height || '';
-    const width = req.query.width || '100%';
+    const height = '100%';
+    const width = '100%';
 
     consoleLogger.debug("/example/:manifestType/:uniqueIdentifier");
     consoleLogger.debug(`uniqueIdentifier ${uniqueIdentifier} manifestType ${manifestType} manifestVersion ${manifestVersion} height ${height} width ${width} productionOverride ${productionOverride}`);

--- a/views/example.eta
+++ b/views/example.eta
@@ -4,7 +4,7 @@
   <%~ includeFile("./intro-message") %>
   <% if (it.viewerURL) { %>
   <div class="row">
-    <div class="col-md-12">
+    <div class="col-md-12 viewer-wrapper">
       <%~ it.viewerURL %>
     </div>
   </div>


### PR DESCRIPTION

**Adding style to account for embed always returning 100% height and 100% width.**
* * *

**JIRA Ticket**: [LTSVIEWER-274](https://at-harvard.atlassian.net/browse/LTSVIEWER-274)

# What does this Pull Request do?
This updates the stylesheet and api calls to mps-embed to account for the fact that mps-embed always returns height=100% and width=100% in the iframe tag.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild `mps-embed` off of the `LTSVIEWER-274` branch first!
* Rebuild `mps-viewer` off of the `LTSVIEWER-274` branch.
* Go to any link on the homepage. The viewer should display with full width and 700px height.
* If you adjust the zoom in your browser, the viewer controls still completely display and are accessible.
* The unit tests still pass.  In the container you can run `npm run test` and see them all pass.
* The manifests route (which CURIOSity uses) is also working the same way. You can try out examples with any iiif manifest like this: https://localhost:23017/example/manifest/?manifestId=https://iiif.lib.harvard.edu/manifests/drs:7065335

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? Yes
- integration tests? No

# Interested parties
@enriquediaz @f8f8ff 