### PR TITLE
Adding ability to turn off file logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log*
 lerna-debug.log*
 /public/js/dist/*
 !/public/js/dist/.keep
+.bash_history
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/app.js
+++ b/app.js
@@ -45,7 +45,11 @@ app.use(cookieParser(process.env.COOKIE_SECRET));
 // Log API requests to console
 app.use(requestLogger('dev', { skip: skipLogs }));
 // Log API requests in the Apache combined format to one log file per day
-app.use(requestLogger('combined', { stream: requestLogStream, flags: 'a', skip: skipLogs }));
+if (process.env.SKIP_FILE_LOGGING ){
+    app.use(requestLogger('combined', {skip: skipLogs }));
+} else {
+    app.use(requestLogger('combined', { stream: requestLogStream, flags: 'a', skip: skipLogs }));
+}
 
 // Routes
 app.use(['/healthcheck'], (req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -3,8 +3,7 @@
 const express = require('express');
 const path = require('path');
 const favicon = require('serve-favicon');
-const requestLogStream = require('./logger/logger.js').requestLogStream;
-const consoleLogger = require('./logger/logger.js').console;
+const { requestLogStream, console: consoleLogger, skipLogs } = require('./logger/logger.js');
 const requestLogger = require('morgan');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
@@ -42,17 +41,11 @@ app.use(express.urlencoded({ extended: false }));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser(process.env.COOKIE_SECRET));
 
-/* Logs for API requests */
-// Logs to skip based on url pattern
-function skipLog(req, res) {
-    const answer = req.originalUrl.indexOf('healthcheck') > -1;
-    return answer;
-}
 // Request Logger
 // Log API requests to console
-app.use(requestLogger('dev', { skip: skipLog }));
+app.use(requestLogger('dev', { skip: skipLogs }));
 // Log API requests in the Apache combined format to one log file per day
-app.use(requestLogger('combined', { stream: requestLogStream, flags: 'a', skip: skipLog }));
+app.use(requestLogger('combined', { stream: requestLogStream, flags: 'a', skip: skipLogs }));
 
 // Routes
 app.use(['/healthcheck'], (req, res, next) => {

--- a/env-example.txt
+++ b/env-example.txt
@@ -9,3 +9,6 @@ HTTPS_REJECT_UNAUTHORIZED=false
 
 # Determine what pdiiif coverpage endpoint to use
 PDIIIF_COVERPAGE_ENDPOINT=http://localhost:8080/api/coverpage
+
+# Set this to true to log to stdout. Set it to false to log to files. Default is false.
+LOG_TO_STDOUT=false

--- a/env-example.txt
+++ b/env-example.txt
@@ -10,5 +10,5 @@ HTTPS_REJECT_UNAUTHORIZED=false
 # Determine what pdiiif coverpage endpoint to use
 PDIIIF_COVERPAGE_ENDPOINT=http://localhost:8080/api/coverpage
 
-# Set this to true to log to stdout. Set it to false to log to files. Default is false.
-LOG_TO_STDOUT=false
+# Set this to true to log to stdout. Set it to empty to log to files.
+SKIP_FILE_LOGGING=true

--- a/logger/logger.js
+++ b/logger/logger.js
@@ -4,14 +4,26 @@ const os = require('os');
 const hostname = os.hostname();
 const rfs = require('rotating-file-stream');
 require('winston-daily-rotate-file');
+const dateFns = require('date-fns');
 
 const logger = {};
 
-// Console logs and errors write to file using winston
-logger.console = winston.createLogger({
-    level: 'debug',
-    format: winston.format.json(),
-    transports: [
+logger.logLevel = process.env.APP_LOG_LEVEL || 'debug';
+
+logger.dateFormatStr = 'yyyy-MM-dd';
+
+logger.dateNow = dateFns.format(new Date(), logger.dateFormatStr);
+
+logger.skipRoutes = [
+  "/version",
+  "/healthcheck",
+  "/robots.txt",
+  "/favicon.ico"
+];
+
+let consoleTransports = '';
+if (process.env.LOG_TO_STDOUT === 'false') {
+    consoleTransports = [
         new winston.transports.DailyRotateFile(
             {
                 filename: `logs/${hostname}/console/%DATE%-console.log`,
@@ -21,13 +33,37 @@ logger.console = winston.createLogger({
             }),
         new winston.transports.Console({ format: winston.format.simple() })
     ]
+}
+else {
+    consoleTransports = [
+        new winston.transports.Console({ format: winston.format.simple() })
+    ];
+}
+
+logger.skipLogs = (req, res) => {
+  let skipLogsAnswer = false;
+  logger.skipRoutes.forEach(routeToSkip => {
+    if (req.originalUrl && req.originalUrl.indexOf(routeToSkip) > -1) {
+      skipLogsAnswer = true;
+    }
+  });
+  return skipLogsAnswer;
+}
+
+// Console logs and errors write to file using winston
+logger.console = winston.createLogger({
+  level: logger.logLevel,
+  format: winston.format.json(),
+  transports: consoleTransports
 });
 
-// API request logs write to file config
-logger.requestLogStream = rfs.createStream('request.log', {
+if (process.env.LOG_TO_STDOUT === 'false') {
+    // API request logs write to file config
+    logger.requestLogStream = rfs.createStream(`./${hostname}_request_${logger.dateNow}.log`, {
     interval: '1d', // Rotate daily
     maxFiles: 30, // Maximum number of rotated files to keep in storage
-    path: path.join(__dirname, `../logs/${hostname}/request/`)
-});
+    path: path.join(__dirname, `../logs`)
+    });
+}
 
 module.exports = logger;

--- a/logger/logger.js
+++ b/logger/logger.js
@@ -1,4 +1,5 @@
-const winston = require('winston');
+const { createLogger, format, transports } = require('winston');
+const { combine, timestamp, label, printf } = format;
 const path = require('path');
 const os = require('os');
 const hostname = os.hostname();
@@ -24,19 +25,20 @@ logger.skipRoutes = [
 let consoleTransports = '';
 if (process.env.LOG_TO_STDOUT === 'false') {
     consoleTransports = [
-        new winston.transports.DailyRotateFile(
-            {
-                filename: `logs/${hostname}/console/%DATE%-console.log`,
-                datePattern: 'yyyy-MM-DD',
-                maxSize: '20m',
-                maxFiles: '14d'
-            }),
-        new winston.transports.Console({ format: winston.format.simple() })
+      new transports.DailyRotateFile(
+        {
+          filename: `${hostname}_console_%DATE%.log`,
+          dirname: `logs`,
+          dateFormat: logger.dateFormatStr,
+          maxSize: '20m',
+          maxFiles: '14d'
+        }),
+      new transports.Console({ format: format.simple() })
     ]
 }
 else {
     consoleTransports = [
-        new winston.transports.Console({ format: winston.format.simple() })
+      new transports.Console({ format: format.simple() })
     ];
 }
 
@@ -50,20 +52,31 @@ logger.skipLogs = (req, res) => {
   return skipLogsAnswer;
 }
 
+const loggerFormat = printf(info => {
+  if(info instanceof Error) {
+      return `${info.timestamp} ${info.level}: ${info.message} ${info.stack}`;
+  }
+  return `${info.timestamp} ${info.level}: ${info.message}`;
+});
+
 // Console logs and errors write to file using winston
-logger.console = winston.createLogger({
+logger.console = createLogger({
   level: logger.logLevel,
-  format: winston.format.json(),
+  format: combine(
+    format.splat(),
+    timestamp(),
+    loggerFormat
+  ),
   transports: consoleTransports
 });
 
 if (process.env.LOG_TO_STDOUT === 'false') {
-    // API request logs write to file config
-    logger.requestLogStream = rfs.createStream(`./${hostname}_request_${logger.dateNow}.log`, {
+  // API request logs write to file config
+  logger.requestLogStream = rfs.createStream(`./${hostname}_request_${logger.dateNow}.log`, {
     interval: '1d', // Rotate daily
     maxFiles: 30, // Maximum number of rotated files to keep in storage
     path: path.join(__dirname, `../logs`)
-    });
+  });
 }
 
 module.exports = logger;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "body-parser": "^1.20.2",
         "bootstrap": "^5.2.3",
         "cookie-parser": "^1.4.6",
+        "date-fns": "^3.3.1",
         "eta": "^2.0.1",
         "express": "^4.18.2",
         "express-validator": "^6.15.0",
@@ -3045,6 +3046,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9019,10 +9019,11 @@
       "license": "MIT"
     },
     "node_modules/winston": {
-      "version": "3.10.0",
-      "license": "MIT",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
       "dependencies": {
-        "@colors/colors": "1.5.0",
+        "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
@@ -9064,6 +9065,14 @@
       },
       "engines": {
         "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "body-parser": "^1.20.2",
     "bootstrap": "^5.2.3",
     "cookie-parser": "^1.4.6",
+    "date-fns": "^3.3.1",
     "eta": "^2.0.1",
     "express": "^4.18.2",
     "express-validator": "^6.15.0",


### PR DESCRIPTION
**Adding ability to turn off file logging.**
* * *
* 

# What does this Pull Request do?
This adds a new environment variable `LOG_TO_STDOUT` which allows you to toggle the saving of the logs to a file. The format of the file logging is also changed slightly to match what is in the `node-ci-template` repository (see: https://github.com/harvard-lts/node-ci-template).

# How should this be tested?

A description of what steps someone could take to:
* Add the `LOG_TO_STDOUT` variable to your local `.env` file. Set it to `false`.
* Rebuild the container from the `stdout-log` branch
* Click around on the site and confirm that the logging is displaying in stdout as well as in files on your local computer.
* Take down the container and change the `LOG_TO_STDOUT` variable to `true`
* Rebuild the container
* Click around on the site and confirm that the logging is displaying in stdout only.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No