### PR TITLE
Fixing undefined error messages.

### DIFF
--- a/controllers/embed.ctrl.js
+++ b/controllers/embed.ctrl.js
@@ -34,7 +34,7 @@ embedCtrl.getEmbed = async (uniqueIdentifier, manifestType = 'mps', manifestVers
   try {
     data = await httpCtrl.makeRequest(requestOptionsData);
   } catch(e) {
-    consoleLogger.error(e);
+    consoleLogger.error(e.message);
     throw new Error(e);
   }
 

--- a/controllers/http.ctrl.js
+++ b/controllers/http.ctrl.js
@@ -60,10 +60,10 @@ httpCtrl.makeRequest = async (requestOptionsData) => {
       // The request was made but no response was received
       // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
       // http.ClientRequest in node.js
-      consoleLogger.error(error.request);
+      consoleLogger.error(JSON.stringify(error.request));
     } else {
       // Something happened in setting up the request that triggered an Error
-      consoleLogger.error(error.message);
+      consoleLogger.error(JSON.stringify(error.message));
     }
     return response.error = `HTTP request error url: ${requestOptionsData.url}`;
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -74,6 +74,7 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     let title = '';
     let iiifManifest = '';
     let errorMsg = '';
+    let embed = '';
     // Unique identifier will be a urn (mps) or record identifier (legacy)
     const uniqueIdentifier = req.params.uniqueIdentifier;
     // Manifest type will be either 'mps' or 'legacy'
@@ -92,7 +93,7 @@ router.get("/example/:manifestType/:uniqueIdentifier", async (req, res) => {
     try {
       embed = await embedCtrl.getEmbed(uniqueIdentifier, manifestType, manifestVersion, height, width, productionOverride);
     } catch(e) {
-      consoleLogger.error(e);
+      consoleLogger.error(e.message);
     }
 
     if (embed) {


### PR DESCRIPTION
**Fixing undefined error messages.**
* * *

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Some error messages were just displaying a message that said "undefined" instead of something more helpful. This fixes it so the messages are helpful.

# How should this be tested?

A description of what steps someone could take to:
* Rebuild mps-viewer off of the `fix-error-message` branch
* Do not have mps-embed running locally.
* Attempt to go to any example item in mps-viewer.
* An actual error message should appear in the log.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No